### PR TITLE
Unified decision record format for KB templates

### DIFF
--- a/docs/design-notes/2026-06-04.TODO.decisions-dir-consolidation.md
+++ b/docs/design-notes/2026-06-04.TODO.decisions-dir-consolidation.md
@@ -1,9 +1,14 @@
 ---
 title: "Consolidate decisions/ and design-notes/ into a unified format"
 tags: [decisions, adr, templates, documentation]
+status: decided
+decision: "Consolidate into a single decisions/ directory using MADR-style serial numbering (nnnn-slug.md), enriched YAML frontmatter with a decision: TL;DR field, and a unified template with Context / Exploration / Decision / Consequences / Confirmation sections."
+review_date: 2026-09-05
+related_to: ["KB-1", "KB-2", "KB-3", "VID-670"]
+supersedes: ""
 ---
 
-# Design Note: Consolidate decisions/ and design-notes/ into a unified format
+# Consolidate decisions/ and design-notes/ into a unified format
 
 > *Authored by Claude Code.*
 
@@ -11,8 +16,9 @@ tags: [decisions, adr, templates, documentation]
 
 | Status | Date       | Author | Related Tickets                                                | Notes                                                    |
 | :----- | :--------- | :----- | :------------------------------------------------------------- | :------------------------------------------------------- |
-| TODO   | 2026-06-04 | claude | [VID-666](https://linear.app/asabina/issue/VID-666)           | Initial creation via designnote; research complete        |
-| WIP    | 2026-06-05 | claude | [VID-666](https://linear.app/asabina/issue/VID-666), [Z-600](https://linear.app/asabina/issue/Z-600), [Z-601](https://linear.app/asabina/issue/Z-601), [VID-670](https://linear.app/asabina/issue/VID-670) | All 5 open questions resolved via sparring; filed follow-up tickets |
+| TODO   | 2026-06-04 | claude | [KB-7](https://linear.app/asabina/issue/KB-7)                 | Initial creation via designnote; research complete        |
+| WIP    | 2026-06-05 | claude | [KB-7](https://linear.app/asabina/issue/KB-7), [KB-2](https://linear.app/asabina/issue/KB-2), [KB-1](https://linear.app/asabina/issue/KB-1), [VID-670](https://linear.app/asabina/issue/VID-670) | All 5 open questions resolved via sparring; filed follow-up tickets |
+| DONE   | 2026-06-05 | claude | [KB-7](https://linear.app/asabina/issue/KB-7) | Decision finalized; frontmatter updated to new schema |
 
 ## Context
 
@@ -104,9 +110,9 @@ Research (Gloaguen et al. 2026) shows bulk-dumping documentation degrades AI age
 - daddal001/universal-ai-driven-documentation-standard
 - bmaher-pcty/agentic-dev-framework
 
-## Recommendation
+## Decision
 
-**Option C — Unified format in `decisions/`.**
+Consolidate into a single `decisions/` directory using MADR-style serial numbering (`nnnn-slug.md`), enriched YAML frontmatter with a `decision:` TL;DR field, and a unified template with Context / Exploration / Decision / Consequences / Confirmation sections.
 
 The two-stage pipeline (design doc → ADR) was designed for large orgs with formal review processes. For small teams where AI agents are co-authors and primary consumers, the overhead of maintaining two directories with overlapping purpose isn't justified. The evidence supports a single directory with:
 

--- a/docs/design-notes/2026-06-04.TODO.decisions-dir-consolidation.md
+++ b/docs/design-notes/2026-06-04.TODO.decisions-dir-consolidation.md
@@ -1,0 +1,215 @@
+---
+title: "Consolidate decisions/ and design-notes/ into a unified format"
+tags: [decisions, adr, templates, documentation]
+---
+
+# Design Note: Consolidate decisions/ and design-notes/ into a unified format
+
+> *Authored by Claude Code.*
+
+## Status Log
+
+| Status | Date       | Author | Related Tickets                                                | Notes                                                    |
+| :----- | :--------- | :----- | :------------------------------------------------------------- | :------------------------------------------------------- |
+| TODO   | 2026-06-04 | claude | [VID-666](https://linear.app/asabina/issue/VID-666)           | Initial creation via designnote; research complete        |
+| WIP    | 2026-06-05 | claude | [VID-666](https://linear.app/asabina/issue/VID-666), [Z-600](https://linear.app/asabina/issue/Z-600), [Z-601](https://linear.app/asabina/issue/Z-601), [VID-670](https://linear.app/asabina/issue/VID-670) | All 5 open questions resolved via sparring; filed follow-up tickets |
+
+## Context
+
+The KB templates ship two separate documentation structures:
+
+- `docs/decisions/` — Architecture Decision Records (ADRs), based on Nygard's format (Context / Decision / Rationale / Consequences). Immutable by convention.
+- `docs/design-notes/` — Living design exploration documents with a status log, richer lifecycle, and two completion paths (Path A: graduate to ADR; Path B: standalone documentation).
+
+In practice across projects, `decisions/` sees little use. Decisions tend to get made *within* design notes — the Context, Exploration, and Recommendation sections already capture what an ADR would. Maintaining both creates duplication, sync overhead, and ambiguity about where to look for "the decision."
+
+The question: should we drop, keep, or merge?
+
+### Why this matters more now (agentic engineering)
+
+Research (Gloaguen et al. 2026) shows bulk-dumping documentation degrades AI agent performance by 20%+. Two directories with overlapping purpose doubles the search surface for agents. Additionally:
+
+- **Rationale starvation** causes 86–87% decision drift in long AI sessions (projectedanx research). The "why" behind a decision must be front-and-center, not buried or split across two files.
+- **Temporal validity** matters — 86% of stale architectural decisions are discovered reactively during incidents. Records need review/expiry dates, which neither current template has.
+- **Bidirectional linking** between agent instructions and decision records is an emerging best practice — a single directory is easier to reference.
+
+## Exploration
+
+### Option A — Drop decisions/, enhance design notes
+
+- Remove `decisions/` from KB templates entirely
+- Add "Decision" and "Consequences" sections to the design note template
+- All records live in `docs/design-notes/`
+
+**Pros:** Simplest change, no new concepts. One directory to scan.
+**Cons:** "Design notes" as a name doesn't convey that some records are authoritative decisions. Agents can't use the directory name as a signal for "this is settled."
+
+### Option B — Keep both, clarify usage
+
+- Tighten the README for each directory
+- Add explicit "when to use which" guidance
+- Keep the existing two-stage pipeline (design doc → ADR)
+
+**Pros:** Matches the broader ADR community pattern (Spotify, Google). Immutable ADRs stay pure.
+**Cons:** Nobody uses `decisions/` in practice. The two-stage pipeline assumes larger organizations with formal review processes. The overhead isn't justified for small teams with AI agents.
+
+### Option C — Unified format in decisions/ (emerging recommendation)
+
+- One directory: `decisions/`
+- One template that starts as exploration and graduates in place
+- Sections: Context, Exploration, Decision, Consequences, Confirmation
+- YAML frontmatter with structured metadata: `status`, `review_date`, `related_to`, `supersedes`
+- Immutability hybrid: once status is `decided`, the Decision and Consequences sections are frozen; amendments go in the status log
+
+**Pros:**
+- Single directory = single search surface for agents and humans
+- Filesystem-level signal: everything in `decisions/` is either being explored or settled
+- Frontmatter-filterable: `grep -rl "^status: decided"` gives you all settled decisions
+- The name "decisions" is more authoritative than "design-notes" — it signals that this directory is where load-bearing choices are recorded
+- Graduated-in-place avoids the sync problem (no copying from one file to another)
+- Hybrid immutability preserves the ADR insight (rationale should be frozen) without the rigidity
+
+**Cons:**
+- Breaks the ADR community's separation of deliberation and verdict
+- "decisions/" as a name for exploratory docs may confuse people expecting traditional ADRs
+- Requires migration for downstream repos that already use both directories
+
+## Research Evidence
+
+| Finding | Source | Implication |
+|---|---|---|
+| ADR community has NOT converged on merging design docs and ADRs | Henderson, Spotify, Harmel-Law | Two-stage pipeline is the default in large orgs |
+| But: small teams with AI agents are a different context | Observation | Community patterns assume human-to-human with organizational memory |
+| MADR 4.0 is the leading structured format | adr/madr (2.2k stars) | YAML frontmatter, Confirmation section, RACI roles |
+| Rationale starvation → 86–87% decision drift | projectedanx research | "Why" must be prominent, not buried |
+| YAML frontmatter is consensus for machine-parseability | Multiple repos | status, relationships, review_date in frontmatter |
+| Bulk-dumping docs degrades agent performance 20%+ | Gloaguen et al. 2026 | Keep records short; one-slide rule (Zimmermann) |
+| 86% of stale decisions found reactively during incidents | projectedanx | Records need review/expiry dates |
+| Immutability has softened — hybrid model emerging | Henderson, Harmel-Law | Frozen context/rationale; living status/consequences |
+| Bidirectional linking between agent instructions and decisions | Multiple repos | AGENTS.md ↔ decisions/ cross-reference |
+| MADR 4.0 adds "Confirmation" section | adr/madr | "How do we verify this was followed?" is new best practice |
+| Lightweight consensus: "one presentation slide" | Zimmermann 2023 | Mega-ADR anti-pattern; keep records short |
+| ThoughtWorks Radar Vol. 34: architecture drift reduction with LLMs at Assess | ThoughtWorks | LLMs as fitness functions evaluating code against ADRs |
+
+### Sources consulted
+
+- adr.github.io (ADR organization hub)
+- github.com/adr/madr — MADR 4.0.0 (September 2024)
+- github.com/joelparkerhenderson/architecture-decision-record
+- martinfowler.com — Harmel-Law, "Scaling Architecture Conversationally" (2021)
+- ozimmer.ch — Zimmermann, ADR creation practices (2023)
+- ThoughtWorks Technology Radar Vol. 34 (April 2026)
+- projectedanx/public-context-hub — DRP-ADR-MEMORY-404
+- Gloaguen et al. (2026) — context file performance impact study
+- daddal001/universal-ai-driven-documentation-standard
+- bmaher-pcty/agentic-dev-framework
+
+## Recommendation
+
+**Option C — Unified format in `decisions/`.**
+
+The two-stage pipeline (design doc → ADR) was designed for large orgs with formal review processes. For small teams where AI agents are co-authors and primary consumers, the overhead of maintaining two directories with overlapping purpose isn't justified. The evidence supports a single directory with:
+
+1. YAML frontmatter for machine-parseable metadata (status, review_date, related_to, supersedes)
+2. A template that supports the full lifecycle from exploration to settled decision
+3. Hybrid immutability: frozen rationale once decided, living status metadata
+4. Short records optimized for agent context windows
+
+### Filename convention
+
+**MADR-style serial numbering:** `nnnn-slug.md` (e.g. `0001-select-apm.md`).
+
+Rationale for choosing serial numbers over dates:
+- Cross-references are clean: `supersedes: "0003"` is readable and unambiguous
+- Dates don't buy much when frontmatter already has a `created` field
+- Revisiting the same topic gets a new serial: `0003-select-apm.md` → `0019-select-apm.md` with `supersedes: "0003"` linking them
+- Branch collision on the counter is rare at our scale and resolves like any merge conflict. Convention: check `ls docs/decisions/ | sort -n | tail -1` before creating.
+
+The **slug generation protocol** (how to arrive at deterministic, reproducible slugs) is a skill-level concern tracked in [Z-601](https://linear.app/asabina/issue/Z-601).
+
+> **Note:** This supersedes the filename convention in [2025-09-08.DONE.documentation-discovery-and-tagging-strategy.md](./2025-09-08.DONE.documentation-discovery-and-tagging-strategy.md) which established the `YYYY-MM-DD.[STATE].description.md` pattern. The tagging strategy (frontmatter tags, grep-based discovery) remains fully valid.
+
+### Frontmatter schema
+
+```yaml
+---
+title: "Human-Readable Title"
+tags: [tag1, tag2]
+status: exploring | decided | superseded | deprecated
+decision: ""              # one-line TL;DR, filled when status becomes "decided"
+review_date: YYYY-MM-DD   # when should this be revisited?
+related_to: []             # serial numbers of related records (e.g. ["0003", "0007"])
+supersedes: ""             # serial number of superseded record (e.g. "0003")
+---
+```
+
+The `decision:` field is the machine-readable index. It enables robust grepping:
+
+```bash
+# Every record's status and verdict in one pass
+grep -E "^(status|decision):" docs/decisions/*.md
+```
+
+This avoids the brittleness of `grep -A1 "^## Decision"` which breaks on blank lines between the heading and the TL;DR paragraph. The `## Decision` section in the body has the full rationale; the frontmatter field is the index-friendly summary.
+
+### Template sections
+
+```
+## Context
+## Exploration
+## Decision          ← full rationale; first paragraph mirrors the frontmatter decision: field
+## Consequences      ← positive and negative outcomes of this decision
+## Confirmation      ← how we verify this decision was followed (enforcement hooks)
+```
+
+**Confirmation** (from MADR 4.0) answers: "how do we know this was implemented correctly?" Examples:
+- "CI enforces merge-commit strategy via branch protection rules"
+- "Pre-commit hook validates subject line length"
+- "Code review checklist includes checking for `[ai:agent]` trailer"
+
+This bridges "we decided X" and "something enforces X" — high value for agents that need to know where enforcement lives.
+
+For records still in `status: exploring`, the Decision, Consequences, and Confirmation sections are empty or carry `_No decision yet._`
+
+### Status log table
+
+**Keep it.** The status log table from the current design-notes template coexists with the frontmatter `status` field:
+- Frontmatter `status` → quick machine filtering
+- Status log table → human-readable history (multi-author tracking, ticket links, dated transitions)
+
+Skills that write to `docs/decisions/` must maintain the status log table — tracked in [VID-670](https://linear.app/asabina/issue/VID-670).
+
+### Directory naming
+
+**`decisions/`** — the name describes the destination, not the current state of every record. The `status: exploring` field handles records that aren't decided yet. Raw ideas that aren't ready for exploration belong in `TODO.md` under Later/Never — the bar for creating a record in `decisions/` is "someone is actively thinking about this."
+
+### Migration path
+
+Stateless instructions via the KB CHANGELOG ([Z-600](https://linear.app/asabina/issue/Z-600)). Format: "If you see X artifacts, you are on a previous version and should migrate by doing Y." No need for version tracking — the presence of specific artifacts (e.g. a `docs/design-notes/` directory) is the signal.
+
+## Resolved Questions
+
+_These were open during exploration and resolved via sparring on 2026-06-05._
+
+1. **Frontmatter schema** → Resolved: title, tags, status, decision (TL;DR), review_date, related_to (serial numbers), supersedes (serial number). See [Frontmatter schema](#frontmatter-schema) above.
+2. **Confirmation section** → Resolved: include it. Bridges "we decided X" and "something enforces X." See [Template sections](#template-sections) above.
+3. **Migration path** → Resolved: stateless instructions in the KB CHANGELOG. See [Migration path](#migration-path) above.
+4. **Directory naming** → Resolved: `decisions/`. The name describes the destination. See [Directory naming](#directory-naming) above.
+5. **Status log table** → Resolved: keep both frontmatter status and status log table. See [Status log table](#status-log-table) above.
+
+## Action Items
+
+- [x] Design the unified template (frontmatter schema + sections) — resolved via sparring 2026-06-05
+- [ ] Update `templates/decisions/` with the new unified template and README (implement the schema and sections above)
+- [ ] Remove `templates/design-notes/` (or convert to a redirect/migration note)
+- [ ] Update `PROJECT_SETUP_GUIDE.md` to reflect single-directory convention
+- [ ] Update `templates/AGENTS.md` to reference `decisions/` instead of the current dual-directory guidance
+- [ ] Migrate engineering skills from dotfiles to KB repo (Linear: [Z-601](https://linear.app/asabina/issue/Z-601))
+- [ ] Update the designnote skill to target `docs/decisions/` instead of `docs/design-notes/` (blocked by Z-601)
+- [ ] Add migration instructions to KB CHANGELOG (Linear: [Z-600](https://linear.app/asabina/issue/Z-600))
+- [ ] Ensure skills maintain status log table on writes (Linear: [VID-670](https://linear.app/asabina/issue/VID-670))
+- [ ] Supersede parts of `2025-09-08.DONE.documentation-discovery-and-tagging-strategy.md` (filename convention change; tagging strategy itself remains valid)
+
+## Related Design Notes
+
+- [2025-09-08.DONE.documentation-discovery-and-tagging-strategy.md](./2025-09-08.DONE.documentation-discovery-and-tagging-strategy.md) — established the frontmatter tagging convention and `YYYY-MM-DD.[STATE].description.md` filename pattern. This note supersedes the filename convention while preserving the tagging strategy.


### PR DESCRIPTION
## Summary
- Design note exploring whether to consolidate `decisions/` and `design-notes/` into a unified format
- Researched ADR state of the art (MADR 4.0, community patterns, agentic engineering implications)
- Converged on Option C: unified `decisions/` directory with MADR-style serial numbering, enriched frontmatter (including `decision:` TL;DR field), and Confirmation section
- All 5 open design questions resolved via sparring; 3 follow-up tickets filed (Z-600, Z-601, VID-670)

## Test plan
- [ ] Review the design note for completeness and accuracy
- [ ] Confirm the resolved questions match the sparring outcomes
- [ ] Verify follow-up tickets are correctly linked

Closes [VID-666](https://linear.app/asabina/issue/VID-666)

🤖 Generated with [Claude Code](https://claude.com/claude-code)