### PR TITLE
Rolling changelog with stateless migration guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+All notable changes to the KB templates are documented in this file.
+
+This project ships continuously — there are no versioned releases. Each entry is dated when it merges to main. Downstream repos can scan by date to discover what changed since they last synced.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **Migration** section for template changes that require action in downstream repos.
+
+**Migration instructions are stateless.** If you see the described artifacts in your project, the migration applies to you — no need to know which "version" you're on.
+
+---
+
+## [2026-06-05]
+
+### Changed
+- **decisions/ directory** — `templates/decisions/` and `templates/design-notes/` consolidated into a single `decisions/` directory with a unified format. Records use MADR-style serial numbering (`nnnn-slug.md`), enriched YAML frontmatter (`status`, `decision`, `review_date`, `related_to`, `supersedes`), and five sections: Context, Exploration, Decision, Consequences, Confirmation.
+- **Decision template** — `YYYY-MM-DD.TODO.decision-template.md` replaced by `0000-decision-template.md`.
+- **AGENTS.md template** — documentation workflow now references `docs/decisions/` instead of dual-directory structure. Commit strategy delegates to CONTRIBUTING.md. HITL language strengthened. AI provenance section added.
+- **PROJECT_SETUP_GUIDE.md** — setup commands no longer copy `design-notes/`.
+
+### Removed
+- **templates/design-notes/** — directory removed. The `decisions/` directory absorbs the full lifecycle from exploration to settled decision.
+
+### Migration
+
+**If you have `docs/design-notes/` in your project:**
+
+1. Create `docs/decisions/` if it doesn't exist
+2. Move each file from `docs/design-notes/` into `docs/decisions/` with serial numbering:
+   ```bash
+   git mv docs/design-notes/YYYY-MM-DD.STATE.topic.md docs/decisions/NNNN-topic.md
+   ```
+3. Update each file's frontmatter to the new schema:
+   ```yaml
+   ---
+   title: "..."
+   tags: [...]
+   status: exploring | decided | superseded | deprecated
+   decision: ""
+   review_date: YYYY-MM-DD
+   related_to: []
+   supersedes: ""
+   ---
+   ```
+4. Rename section headings: `Recommendation` → `Decision`. Add `## Consequences` and `## Confirmation` sections if missing.
+5. Remove `docs/design-notes/` after all files are moved.
+
+**If you have `docs/decisions/` with the old template (`YYYY-MM-DD.decision-title.md`):**
+
+1. Rename files to serial format: `git mv YYYY-MM-DD.decision-title.md NNNN-decision-title.md`
+2. Update frontmatter to the new schema (see step 3 above)
+3. Rename `## Rationale` → `## Decision` (move the rationale into the body of the Decision section)
+4. Add `## Confirmation` section
+
+**If your AGENTS.md references `DECISIONS.md` or dual-directory structure:**
+
+1. Replace `DECISIONS.md` references with `docs/decisions/` and the grep pattern:
+   ```
+   grep -E "^(status|decision):" docs/decisions/*.md
+   ```
+
+## [2026-06-04]
+
+### Added
+- **CONTRIBUTING.md template** — new file at `templates/CONTRIBUTING.md`. Owns commit conventions, scope discipline (Category A/B), prohibited scope patterns, subject-line self-check protocol, PR merge strategy, and milestone integration branch pattern (optional appendix).
+- **AI Provenance section** in `templates/AGENTS.md` — commit tags and comment prefixes for AI-authored contributions.
+- **HITL language** in `templates/AGENTS.md` — explicit "never create commits, push branches, or open/merge PRs unless asked" framing.
+
+### Changed
+- **AGENTS.md template** — commit strategy section now delegates to CONTRIBUTING.md as canonical source. Pre-commit workflow uses `git add <file>` instead of `git add .`.
+- **PROJECT_SETUP_GUIDE.md** — setup commands now include copying CONTRIBUTING.md to repo root.
+- **Symlink documentation** — AGENTS.md now notes that CLAUDE.md and GEMINI.md are symlinks.
+
+### Migration
+
+**If your project has no CONTRIBUTING.md:**
+
+1. Copy `templates/CONTRIBUTING.md` to your repo root
+2. Populate the scopes table with your project's canonical scopes
+3. Populate the prohibited scope patterns with any project-specific anti-patterns
+
+**If your AGENTS.md has an inline Commit Strategy section:**
+
+1. Replace it with the delegation pointer from the updated `templates/AGENTS.md`:
+   ```
+   > **Read `CONTRIBUTING.md` before drafting or making any commit.**
+   ```
+2. Add the AI Provenance section from the updated template
+
+**If your pre-commit workflow uses `git add .`:**
+
+1. Replace with `git add <file1> <file2>` — never `git add .` or `git add -A`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **
 
 ## [2026-06-05]
 
+### Added
+- **CHANGELOG.md template** — new file at `templates/CHANGELOG.md`. Rolling dated entries, stateless migration instructions, per-logical-change granularity. Adapted for continuous delivery repos without versioned releases.
+
 ### Changed
 - **decisions/ directory** — `templates/decisions/` and `templates/design-notes/` consolidated into a single `decisions/` directory with a unified format. Records use MADR-style serial numbering (`nnnn-slug.md`), enriched YAML frontmatter (`status`, `decision`, `review_date`, `related_to`, `supersedes`), and five sections: Context, Exploration, Decision, Consequences, Confirmation.
 - **Decision template** — `YYYY-MM-DD.TODO.decision-template.md` replaced by `0000-decision-template.md`.

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -163,13 +163,14 @@ Copy the core documentation templates into your project.
 mkdir -p docs
 
 # Copy templates
+cp ../kb/templates/CHANGELOG.md ./
 cp ../kb/templates/CONTRIBUTING.md ./
 cp ../kb/templates/GUIDELINES.md ./docs/
 cp ../kb/templates/TODO.md ./docs/
 cp -r ../kb/templates/decisions ./docs/
 ```
 
-> **Note:** `CONTRIBUTING.md` lives at the repo root (GitHub convention), not in `docs/`.
+> **Note:** `CHANGELOG.md` and `CONTRIBUTING.md` live at the repo root (GitHub convention), not in `docs/`.
 > It owns commit conventions, scope discipline, and merge strategy — see the template for details.
 
 Refer to the main [Engineering Handbook (README.md)](./README.md) for the philosophy on when and how to use each of these documents.

--- a/templates/CHANGELOG.md
+++ b/templates/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/), adapted for continuous delivery:
+
+- **No versioned releases.** Each entry is dated when it merges to main.
+- **Migration sections** accompany breaking template or convention changes so downstream consumers know what to do.
+- **Stateless instructions.** Migration guidance is artifact-based ("if you see X, do Y") — no need to track which version you're on.
+- **Per-logical-change granularity.** One dated entry per coherent change, not per PR. Related PRs share a date entry.
+
+## How to read this changelog
+
+Scan from the top. Find the date after your last sync. Everything above that date is new to you. Migration sections tell you what action to take, if any.
+
+## How to write an entry
+
+1. Add a new `## [YYYY-MM-DD]` heading at the top (below this intro)
+2. Categorize changes under `### Added`, `### Changed`, `### Removed`, `### Fixed`, or `### Deprecated`
+3. If any change requires action from consumers, add a `### Migration` section with stateless instructions
+4. Keep entries concise — link to tickets or design notes for full context
+
+<!-- Template entry — copy and fill in:
+
+## [YYYY-MM-DD]
+
+### Added
+- **Feature name** — brief description of what was added.
+
+### Changed
+- **Component name** — what changed and why.
+
+### Removed
+- **Component name** — what was removed and what replaces it (if anything).
+
+### Migration
+
+**If you have [artifact/pattern] in your project:**
+
+1. Step one
+2. Step two
+3. Step three
+
+-->


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with rolling dated entries (no Unreleased section — the KB ships continuously)
- Each entry includes Added/Changed/Removed categories plus a **Migration** section with stateless instructions
- Migration instructions are artifact-based: "if you see X in your project, do Y" — no version tracking needed
- Covers both today's decisions/ consolidation (2026-06-05) and yesterday's CONTRIBUTING.md addition (2026-06-04)

## Test plan
- [ ] Verify migration instructions are actionable without knowing the "version"
- [ ] Verify all template changes from KB-3 and KB-8 are covered
- [ ] Confirm changelog format follows keepachangelog.com conventions

Stacked on PR #31 (KB-8) → PR #30 (KB-7)

Closes [KB-2](https://linear.app/asabina/issue/KB-2/kb-changelog-with-downstream-migration-guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)