### PR TITLE
Commit .envrc directly, drop .envrc.example pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **
 
 ## [2026-06-05]
 
+### Changed
+- **`.envrc` template** — renamed from `.envrc.example` to `.envrc`. The file is now committed directly to repos (no copy step). It contains only direnv/devenv boilerplate — no secrets. Secrets remain in `.envrc.local` (gitignored).
+- **`.gitignore` template** — `.envrc` removed from gitignore entries. Only `.envrc.local` and `.env*` secret files are gitignored.
+- **PROJECT_SETUP_GUIDE.md** — environment setup simplified: one fewer copy step, explicit note that `.envrc` is committed.
+
+### Migration
+
+**If your project gitignores `.envrc`:**
+
+1. Remove `.envrc` from your `.gitignore`
+2. Commit your existing `.envrc` file: `git add .envrc && git commit -m "chore: track .envrc (no secrets, devenv boilerplate only)"`
+3. Verify `.envrc.local` is still gitignored (it holds secrets)
+4. Remove `.envrc.example` if present — it is no longer needed: `git rm .envrc.example`
+
+## [2026-06-05]
+
 ### Added
 - **CHANGELOG.md template** — new file at `templates/CHANGELOG.md`. Rolling dated entries, stateless migration instructions, per-logical-change granularity. Adapted for continuous delivery repos without versioned releases.
 

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -13,45 +13,46 @@ We use a **direnv -> devenv** pattern for environment management. This provides 
 > [!WARNING]
 > Avoid devenv's `dotenv.enable = true` option. It only supports basic `key=value` pairs and will cause frustration. Use `.envrc.local` for full bash support, including variable expansion (`${VAR}`) and command execution (`$(cmd)`).
 
-**A. Copy Environment Templates**
+**A. Copy Environment Files**
 
-Copy the example files from the knowledge base into your new project's root.
+Copy the environment files from the knowledge base into your new project's root.
 
 ```bash
 # Example assumes knowledge-base is cloned next to your project
-cp ../kb/templates/.envrc.example .envrc.example
+cp ../kb/templates/.envrc .envrc
 cp ../kb/templates/.envrc.local.example .envrc.local.example
 ```
 
-**B. Create Working Environment Files**
+`.envrc` is committed directly — it contains only direnv/devenv boilerplate, no secrets. Secrets go in `.envrc.local` (gitignored).
 
-Instruct developers to create their own working files from the examples.
+**B. Configure `.gitignore`**
 
-```bash
-cp .envrc.example .envrc
-cp .envrc.local.example .envrc.local
-```
-
-**C. Configure `.gitignore`**
-
-Ensure local environment files are never committed. Add them to your project's `.gitignore`.
+Ensure secret files are never committed. Add them to your project's `.gitignore`.
 
 ```bash
 echo "" >> .gitignore
-echo "# Local environment files" >> .gitignore
-echo ".envrc" >> .gitignore
+echo "# Local secrets and overrides" >> .gitignore
 echo ".envrc.local" >> .gitignore
 ```
 
-**D. Allow Direnv**
+> **Note:** Do NOT gitignore `.envrc` — it is committed. Only `.envrc.local` (which holds secrets) is gitignored.
 
-Once `.envrc` is present, `direnv` will prompt for permission on first entry into the directory.
+**C. Allow Direnv**
+
+On first clone (or after `.envrc` changes), `direnv` will prompt for permission.
 
 ```bash
 direnv allow
 ```
 
-This command loads the environment and integrates with `devenv` as configured in the template.
+**D. Set Up Local Secrets**
+
+Each developer creates their own `.envrc.local` from the example:
+
+```bash
+cp .envrc.local.example .envrc.local
+# Edit .envrc.local with your secrets (1Password refs, API keys, etc.)
+```
 
 **E. Customize for Your Project**
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Optionally, use [devenv](https://devenv.sh) to manage your dev environments.
 We use a **direnv -> devenv** pattern to manage environment variables. This provides a consistent, reproducible development environment while keeping secrets secure and local.
 
 - **`devenv.nix`** defines shared, non-sensitive variables for the team.
-- **`.envrc` and `.envrc.local`** (loaded by direnv) manage local configuration and secrets, with support for dynamic values from tools like 1Password.
+- **`.envrc`** (committed to repo) contains direnv/devenv boilerplate — no secrets. **`.envrc.local`** (gitignored) holds secrets and local overrides, with support for dynamic values from tools like 1Password.
 
 For a complete, step-by-step guide to setting this up in a new project, see the **[Project Setup Guide](./PROJECT_SETUP_GUIDE.md#1-environment-setup-recommended-first-step)**.
 

--- a/templates/.envrc
+++ b/templates/.envrc
@@ -1,7 +1,7 @@
-# .envrc.example - Development environment template
+# .envrc - Development environment (committed to repo)
 #
-# Copy this file to .envrc to set up your development environment.
-# This file uses the direnv -> devenv pattern for env management.
+# This file is committed directly — no copy step needed.
+# Secrets and local overrides go in .envrc.local (gitignored).
 #
 # See knowledge-base/README.md "Environment Variable Management Pattern" for details.
 

--- a/templates/.gitignore.example
+++ b/templates/.gitignore.example
@@ -1,14 +1,13 @@
-# Environment files - developers create these from .example files
+# Environment files
 # See knowledge-base/README.md#environment-variable-management-pattern
 
-# All working environment files (created by developers from examples)
-.envrc
+# Local secrets and overrides (never committed)
 .envrc.local
 .env
 .env.local
 .env.*.local
 
-# Keep example files committed for team reference:
-# .envrc.example (committed)
-# .envrc.local.example (committed)
-# .env.example (committed)
+# Committed files (do NOT gitignore):
+# .envrc              — direnv/devenv boilerplate, no secrets
+# .envrc.local.example — documents required secrets for the project
+# .env.example         — documents required env vars for the project

--- a/templates/README.md
+++ b/templates/README.md
@@ -73,19 +73,18 @@ This project uses the **direnv -> devenv loading chain** for environment managem
 
 **File Roles:**
 
-- **`.envrc`**: Base configuration template (copied from `.envrc.example`, gitignored)
+- **`.envrc`**: Base configuration (committed to repo — no secrets, pure direnv/devenv boilerplate)
 - **`.envrc.local`**: Personal secrets and local overrides (copied from `.envrc.local.example`, gitignored)
 
 Once you have devenv and direnv installed:
 
-1. **Set up your local environment** by copying the provided template:
+1. **Allow direnv** to load the committed `.envrc`:
 
    ```bash
-   cp .envrc.example .envrc  # Copy the template to create your working environment file
    direnv allow              # Grant direnv permission to load the environment
    ```
 
-   The included `.envrc.example` template provides:
+   The committed `.envrc` provides:
    - Timeout configuration to prevent direnv hangs during long operations
    - Auto-watch functionality for `.envrc.local` changes (secrets reload automatically)
    - Seamless integration with devenv for reproducible development environment
@@ -158,7 +157,7 @@ npm run build --help   # Verify build tools are available
 - Check devenv logs: `devenv info`
 
 > [!NOTE]
-> This project uses **.envrc.local** for local environment variables. All working environment files (`.envrc` and `.envrc.local`) contain your personal configuration and are gitignored. Only the `*.example` files (`.envrc.example`, `.envrc.local.example`) are committed to help teammates understand what configuration is needed.
+> `.envrc` is committed to the repo — it contains only direnv/devenv boilerplate, no secrets. Secrets go in `.envrc.local` (gitignored). The `.envrc.local.example` file documents what secrets are needed.
 
 For complete environment management documentation, see [knowledge-base environment setup guide](https://github.com/asabina-de/kb?tab=readme-ov-file#environment-variable-management-pattern).
 


### PR DESCRIPTION
## Summary
- `.envrc` is now committed to repos (renamed from `.envrc.example`) — it's pure direnv/devenv boilerplate with no secrets
- `.envrc.local` remains gitignored for secrets and local overrides
- Simplifies onboarding: `git clone` + `direnv allow` is all you need (no copy step)
- Aligns with official devenv recommendation

## Changes
- `templates/.envrc.example` → `templates/.envrc` (renamed, header updated)
- `templates/.gitignore.example` — `.envrc` removed from gitignore entries
- `templates/README.md` — setup instructions simplified (no copy step)
- `PROJECT_SETUP_GUIDE.md` — environment setup reordered and simplified
- `README.md` — clarified `.envrc` vs `.envrc.local` roles
- `CHANGELOG.md` — new entry with stateless migration instructions

## Test plan
- [ ] Verify `templates/.envrc` content is unchanged (only header comments differ)
- [ ] Verify `.gitignore.example` no longer lists `.envrc`
- [ ] Verify migration instructions in CHANGELOG are actionable for downstream repos

Closes KB-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)