### PR TITLE
KB-owned engineering skills for artifact co-evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **
 
 ## [2026-06-05]
 
+### Added
+- **`skills/` directory** — engineering skills (commenting, commitmsg, designnote, linearissue, pairprog, pr) migrated from dotfiles to KB repo. Skills that read/write KB-defined artifacts now co-evolve with those artifacts.
+- **Slug generation protocol** — documented in the designnote skill. Deterministic heuristic for generating decision record filenames.
+
+### Changed
+- **designnote skill** — now targets `docs/decisions/` with MADR-style serial numbering (`nnnn-slug.md`), new frontmatter schema (`status`, `decision`, `review_date`, `related_to`, `supersedes`), and unified sections (Context, Exploration, Decision, Consequences, Confirmation).
+- **linearissue skill** — filing mode now reads `docs/decisions/` records. Verification uses frontmatter `status: exploring` instead of filename state tokens.
+
+## [2026-06-05]
+
 ### Changed
 - **`.envrc` template** — renamed from `.envrc.example` to `.envrc`. The file is now committed directly to repos (no copy step). It contains only direnv/devenv boilerplate — no secrets. Secrets remain in `.envrc.local` (gitignored).
 - **`.gitignore` template** — `.envrc` removed from gitignore entries. Only `.envrc.local` and `.env*` secret files are gitignored.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,36 @@
+# Engineering Skills
+
+Claude Code skills that operate on KB-defined artifacts (decision records, TODO.md, commit conventions, CONTRIBUTING.md). These skills live here — not in personal dotfiles — so they co-evolve with the artifacts they read and write.
+
+## Skills in this directory
+
+| Skill | Purpose | KB artifacts touched |
+|-------|---------|---------------------|
+| **commenting** | Post structured comments to Linear issues (threading, provenance, formatting) | None (protocol only) |
+| **commitmsg** | Suggest commit messages following repo conventions | Reads CONTRIBUTING.md, AGENTS.md |
+| **designnote** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
+| **linearissue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
+| **pairprog** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |
+| **pr** | Create pull requests with smart base branch detection | Reads Linear tickets |
+
+## Skills that stay in dotfiles
+
+These are personal/generic and don't couple to KB artifacts:
+
+- `context7-mcp`, `dispatch`, `qsearch`, `troubleshoot`, `untypo`
+
+## Wiring into dotfiles
+
+The dotfiles repo symlinks each skill directory into `claude/skills/`:
+
+```bash
+# In dotfiles/claude/skills/
+commenting  -> <PATH_TO_KB_REPO>/skills/commenting
+commitmsg   -> <PATH_TO_KB_REPO>/skills/commitmsg
+designnote  -> <PATH_TO_KB_REPO>/skills/designnote
+linearissue -> <PATH_TO_KB_REPO>/skills/linearissue
+pairprog    -> <PATH_TO_KB_REPO>/skills/pairprog
+pr          -> <PATH_TO_KB_REPO>/skills/pr
+```
+
+`mkOutOfStoreSymlink` in nix-darwin follows the symlink chain — no config changes needed.

--- a/skills/commenting/SKILL.md
+++ b/skills/commenting/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: commenting
+description: "Use this skill when another skill or the user needs to post a structured comment to a Linear issue. This skill owns the commenting protocol: thread lifecycle (anchor → replies → resolution), provenance markers, formatting, and threading via parentId. Trigger when a skill wants to post an assessment, finding, plan, status update, or session summary to a Linear issue. Also trigger when the user invokes `/commenting`. Do NOT use this skill for reading comments (use list_comments directly) or for creating/updating issues (use save_issue directly). This skill only handles comment creation with proper formatting and threading."
+api_description: "Post structured comments to Linear issues following a uniform protocol: thread anchors, threaded replies, provenance markers, and resolution semantics. Handles formatting and threading so calling skills don't have to."
+allowed-tools: mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__get_issue
+---
+
+# commenting
+
+Post structured comments to Linear issues. This skill owns the **how** of commenting — formatting, provenance, threading. Calling skills own the **what** — when to comment and what content to include.
+
+## Protocol
+
+Every comment follows this structure:
+
+```
+Issue comments:
+├── Thread anchor (top-level): one per unit of work
+│   ├── Reply: interim update
+│   ├── Reply: interim update
+│   └── Reply: completion/resolution
+├── Thread anchor (top-level): another unit of work
+│   └── Reply: completion/resolution
+```
+
+### Comment anatomy
+
+Every comment has three parts:
+
+1. **Heading line:** `**{Title}** ({caller-skill})`
+2. **Provenance line:** `*[ai:claude-code]*`
+3. **Body:** the content, in markdown
+
+Example:
+
+```markdown
+**Assessment** (pairprog)
+
+*[ai:claude-code]*
+
+**Clear and ready:**
+- Add Google OAuth callback endpoint
+- Store refresh tokens in existing session table
+```
+
+### Thread lifecycle
+
+- **Anchor:** A top-level comment that starts a thread. One anchor per logical unit of work (one assessment, one spike, one plan, one session summary). Post with `save_comment(issueId, body)`.
+- **Reply:** A threaded response under an anchor. Used for updates, completions, and corrections to the anchor's unit of work. Post with `save_comment(issueId, body, parentId)` where `parentId` is the anchor's comment ID.
+- **Resolution:** The final reply in a thread. Prefix the heading with ✅ to signal completion: `**✅ Step 1 complete** (pairprog)`. (Linear MCP doesn't expose `resolvedAt`, so the emoji is the visual signal.)
+
+### When to anchor vs reply
+
+| Scenario | Action |
+|---|---|
+| New unit of work (assessment, plan, spike, investigation) | **Anchor** — new top-level comment |
+| Update to an existing unit (step progress, plan adjustment, interim finding) | **Reply** — thread under the anchor |
+| Completion of a unit (step done, session wrap-up, investigation concluded) | **Reply** with ✅ heading — thread under the anchor |
+| Unrelated new unit during same session | **Anchor** — new top-level comment |
+
+### Provenance
+
+The provenance marker identifies the authoring surface:
+
+- `*[ai:claude-code]*` — comment authored by Claude Code (interactive session)
+- `*[ai:managed-agent]*` — comment authored by a managed agent (walk-away)
+
+The marker always appears on line 3 (after heading + blank line), never inline or at the end.
+
+### Mid-thread events
+
+When something changes mid-thread (plan adjusted, step skipped, blocker found), use these emoji prefixes on the heading:
+
+- 🚨 — plan change
+- ⏭️ — step skipped
+- 🌟 — step added
+- 🚧 — blocker discovered
+- ⚠️ — conflict between plan and reality
+
+## Interface
+
+Calling skills invoke this skill via `Skill("commenting", args)` where `args` is a natural-language instruction. The commenting skill parses the intent and calls `save_comment` with proper formatting.
+
+### Anchor examples
+
+```
+Post an anchor comment on VID-123 titled "Assessment" from skill "pairprog" with body:
+
+**Clear and ready:**
+- Item 1
+- Item 2
+
+**Unclear:**
+- Question 1
+```
+
+```
+Post an anchor comment on VID-456 titled "Troubleshoot findings" from skill "troubleshoot" with body:
+
+**Root cause:**
+The config file is missing the API key entry.
+
+**Evidence:**
+- `src/config.ts:42` — reads `process.env.API_KEY` but `.env.example` doesn't list it
+```
+
+### Reply examples
+
+```
+Reply to anchor {comment-id} on VID-123 titled "Step 1 complete" from skill "pairprog" with body:
+
+Added OAuth callback route in `src/routes/auth.ts`.
+Test added — passing.
+Commit: `a1b2c3d`
+```
+
+```
+Reply to anchor {comment-id} on VID-123 titled "🚨 Plan adjusted" from skill "pairprog" with body:
+
+Step 3 replaced with Step 3a: explicit re-login flow.
+Reason: navigator decided silent refresh adds complexity.
+```
+
+### Resolution example
+
+```
+Reply to anchor {comment-id} on VID-123 titled "✅ Session complete" from skill "pairprog" with body:
+
+**Completed:**
+- [x] Step 1: OAuth callback route
+- [x] Step 2: Token storage
+
+**Remaining:**
+- (none — PR created: #47)
+```
+
+## Return value
+
+After posting, the skill returns the comment ID in chat so the calling skill can use it for threading:
+
+```
+Posted anchor comment {comment-id} on VID-123.
+```
+
+or
+
+```
+Posted reply to {parent-id} on VID-123.
+```
+
+The calling skill should store anchor IDs for the duration of its session to thread subsequent replies correctly.
+
+## Anti-patterns
+
+- **Don't post without a heading.** Every comment needs `**{Title}** ({skill})` on line 1.
+- **Don't skip provenance.** Every comment needs `*[ai:claude-code]*` on line 3.
+- **Don't post "starting X" comments.** Wait until X is done, then post findings. One comment per completed unit, not a running log.
+- **Don't interleave parallel results.** When multiple subagents complete, post one combined anchor rather than separate anchors that fragment the timeline.
+- **Don't use top-level comments for updates.** If an anchor exists for this unit of work, reply to it. Only create a new anchor for a genuinely new unit.
+- **Don't post empty resolution replies.** If there's nothing to say beyond "done", fold it into the last substantive reply with the ✅ prefix.

--- a/skills/commitmsg/SKILL.md
+++ b/skills/commitmsg/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: commitmsg
+description: "Use this skill when the user asks for a commit message suggestion based on their current uncommitted changes — or when the user invokes `/commitmsg`. Trigger for prompts like 'suggest a commit message', 'commitmsg', 'what should I commit this as', 'draft a commit', 'write a commit message for this'. The skill reads the repo's own docs (CONTRIBUTING.md, AGENTS.md, README.md) and the org knowledge base (via `./kb` or `./knowledge-base` symlink if present) for commit conventions, inspects the uncommitted diff and recent git history, and prints a suggested commit message in chat. It never commits, stages, or modifies files in normal mode. It also has a setup mode (`--setup`) that inspects git history, repo docs, and the org kb to draft or update the commit convention section in the repo's docs — run this once per repo to bootstrap the convention. Do NOT trigger for actually committing (the user runs git commit themselves), for amending or rebasing (those are direct git operations), for generating changelogs or release notes (different task), or for reviewing code (use a review skill or do it directly)."
+api_description: "Generate a commit message for the current staged diff, following the repo's documented conventions. Reads CONTRIBUTING.md, recent git history, and any org knowledge base for style. Never commits, stages, or modifies files."
+allowed-tools: Bash Glob Grep Read Write Edit AskUserQuestion
+---
+
+# commitmsg
+
+Suggest a **commit message** for the user's current uncommitted changes, following the conventions documented in the repo itself.
+
+The defining design principles of this skill are:
+
+> **The repo's own docs are the source of truth for commit conventions.** The skill reads CONTRIBUTING.md, AGENTS.md, README.md — wherever the repo documents its convention. It does not hardcode any format.
+>
+> **Output only.** In normal mode, the skill prints a suggested commit message in chat and nothing else. No staging, no committing, no file writes. Git is HITL.
+>
+> **Setup bootstraps the convention into the repo's docs.** The `--setup` mode inspects git history, existing docs, and the org kb to draft the commit convention section. Run once per repo, then normal mode reads what setup wrote.
+
+## Normal mode (default)
+
+### Step 1 — Find the convention
+
+Search for commit convention documentation. Check these sources in order, collecting guidance from all that exist (later sources add context, they don't override earlier ones):
+
+1. **Repo docs (primary):**
+   - `CONTRIBUTING.md` — a "Commit" or "Commit Messages" or "Commit Strategy" section
+   - `CLAUDE.md` / `AGENTS.md` — a "Commit Strategy" or "Commit" section
+   - `README.md` — a "Commit Standards" or "Contributing" section that mentions commits
+   - `.github/CONTRIBUTING.md` or `docs/CONTRIBUTING.md`
+
+2. **Org knowledge base (supplementary):** Check for a `./kb` or `./knowledge-base` symlink at the repo root. This is the org convention for providing AI tooling access to the shared engineering handbook. If present, read:
+   - `{kb-symlink}/templates/AGENTS.md` — the "Commit Strategy" section
+   - `{kb-symlink}/templates/README.md` — the "Commit Standards" section
+
+   Where `{kb-symlink}` is whichever of `./kb` or `./knowledge-base` exists (check `./kb` first).
+
+   If neither symlink exists, that's fine — the repo's own docs are sufficient. Setting up the kb symlink is a human operation; the skill never creates it.
+
+3. **Git history (implicit convention):** `git log --oneline -20` — if the docs are sparse, the recent commit history itself reveals the de facto convention (prefixes in use, tag patterns, message length norms).
+
+If none of these sources contain commit convention guidance, warn the user:
+
+> No commit convention found in this repo's docs. Run `/commitmsg --setup` to bootstrap one from git history and the org kb, or I'll fall back to describing the changes without a specific format.
+
+Proceed with a plain descriptive message if the user doesn't want to set up.
+
+### Step 2 — Read the diff
+
+Run via `Bash`:
+
+- `git status` — to see what's staged vs unstaged, untracked files
+- `git diff --cached` — staged changes (this is what `git commit` will include)
+- `git diff` — unstaged changes (flag these as not-yet-staged)
+- `git log --oneline -10` — recent commits for style continuity
+
+If nothing is staged, note this and base the suggestion on the full uncommitted diff (`git diff` + untracked). Mention that the user needs to stage before committing.
+
+### Step 3 — Draft the message
+
+Analyze the changes:
+
+- **What changed:** files touched, nature of the changes (new feature, bug fix, refactor, docs, chore, test, etc.)
+- **Why it changed:** infer from the diff context, variable names, comments, test names. If the "why" isn't clear from the diff alone, say so rather than fabricating intent.
+- **Scope:** if the convention uses scopes (e.g., `feat(auth):`), derive from the primary directory or module affected.
+
+Apply the convention found in Step 1 to format the message. If the convention specifies:
+- A prefix format (e.g., `feat:`, `fix:`) — use it
+- A tag (e.g., `[ai:claude]`) — include it
+- A max length — respect it
+- A body/footer structure — follow it
+
+**Always** include a `Co-Authored-By` trailer, regardless of whether the repo convention specifies one. This is the git-native AI provenance signal and renders distinctly in forge UIs (GitHub, GitLab show it as a secondary author avatar):
+
+```
+Co-Authored-By: Claude Code <noreply@anthropic.com>
+```
+
+Print the suggested message in a fenced code block so the user can copy it.
+
+If the changes span multiple unrelated concerns, suggest breaking into multiple commits and provide a message for each.
+
+### Step 4 — Done
+
+No further action. The user copies the message and runs `git commit` themselves.
+
+## Setup mode (`--setup`)
+
+Triggered when the user passes `--setup` or says something like "set up commit conventions for this repo."
+
+### Step 1 — Inspect existing state
+
+In parallel:
+
+- **Git history:** `git log --oneline -50` — look for patterns: conventional commits, prefixes, tags, co-author lines, scope usage, message length
+- **Repo docs:** read CONTRIBUTING.md, CLAUDE.md, AGENTS.md, README.md for any existing commit guidance
+- **Org kb:** check for `./kb` or `./knowledge-base` symlink. If present, read `templates/AGENTS.md` and `templates/README.md` for the org-level commit convention. If absent, mention that the org convention is to symlink `./kb` or `./knowledge-base` → the shared kb repo, but setting that up is the user's responsibility — the skill never creates symlinks.
+
+Synthesize: what convention is the repo already following (even if undocumented)? Does it match the org kb template? Are there inconsistencies?
+
+### Step 2 — Draft the convention
+
+Print the proposed convention section in chat. This should cover:
+
+- **Format:** the commit message structure (prefix, scope, subject, body, footer)
+- **Prefixes:** which ones are used and what they mean
+- **Tags:** any AI attribution tags
+- **Co-authorship:** how to attribute AI-assisted commits
+- **Length limits:** subject line max, body wrapping
+- **Multi-concern rule:** one commit per logical change
+
+Base this on what the git history actually shows, reconciled with the org kb if available. If the org kb has a convention and the repo doesn't, propose adopting the org convention. If the repo has a convention that diverges from the org kb, flag the divergence for the user to resolve.
+
+### Step 3 — Confirm and write
+
+Use `AskUserQuestion` to confirm:
+
+- **Where to write:** CONTRIBUTING.md (create or append section) / AGENTS.md (append section) / README.md (append section) / Other
+- **Content looks good?** with the drafted section shown in chat
+
+On confirmation, write or append the section to the chosen file via `Write` or `Edit`.
+
+### Step 4 — Done
+
+Print the path written and suggest a commit message for the convention documentation itself.
+
+## Anti-patterns
+
+- **Don't hardcode a commit format.** The convention lives in the repo's docs. If there's no convention, say so — don't silently impose one.
+- **Don't commit or stage.** The skill outputs text. Git operations are HITL.
+- **Don't modify files in normal mode.** Only `--setup` writes to the repo.
+- **Don't fabricate intent.** If the "why" behind a change isn't clear from the diff, say "the intent isn't clear from the diff — you may want to add context in the commit body" rather than guessing.
+- **Don't suggest amending previous commits.** That's a destructive operation the user decides on their own.
+- **Don't hardcode the kb path.** The org kb is discovered via `./kb` or `./knowledge-base` symlink, not via an absolute path. If the symlink isn't there, the kb isn't available — don't go hunting.

--- a/skills/designnote/SKILL.md
+++ b/skills/designnote/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: designnote
+description: "Use this skill when the user asks you to start, extend, or record a decision record — ideation around a design problem, architectural choice, trade-off analysis, open question, or a decision that needs long-term awareness. Trigger for prompts like 'take a note on X', 'design note for X', 'let's think through X', 'capture the options for X', 'document this decision', 'explore trade-offs for X', 'start a dnote for X', 'write up the problem of X', 'we should think about X and park it', 'note the constraints around X', 'ideate on X'. Also trigger when the user invokes `/designnote`. The skill reads existing records, related Linear tickets, and the repo's TODO.md, researches open questions in parallel via subagents, and writes (or extends) a decision record in `docs/decisions/` — OR, for strategy/process/team-facing content, a Linear document. It batches clarifying questions into ONE up-front round so the user can walk away and return to a finished artifact. Do NOT trigger for quick factual questions (use qsearch or answer directly), for code changes (just do the work), for small one-liners that belong in TODO.md (add the line directly without invoking the skill), for operational status updates on existing Linear tickets, or for creating Linear issues from an existing record's action items (that's the linearissue skill)."
+api_description: "Draft or extend a decision record documenting a problem, options considered, trade-offs, and chosen approach. Writes to docs/decisions/ or a Linear document depending on scope. Researches open questions in parallel and batches clarifying questions into one up-front round."
+allowed-tools: Task WebSearch WebFetch AskUserQuestion Glob Grep Read Write Edit mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__save_document mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__search_documentation
+---
+
+# designnote
+
+Draft or extend a **decision record** — a living, evolving document that records a problem, the options considered, the reasoning, the chosen approach, and any open questions that may be revisited. Decision records are the canonical surface for long-lived architectural thinking in this workflow. Records start in `status: exploring` and graduate to `status: decided` when the decision is made.
+
+The defining design principles of this skill are:
+
+> **Batch every clarifying question into one up-front round, then run to completion uninterrupted.**
+>
+> **Persist findings to the decision record as the single source of truth. No parallel work-plan files. No duplicate task representations.**
+>
+> **Prefer extending an existing record to creating a new one. Duplication erodes the knowledge base.**
+
+The user should be able to kick this off, answer a small batch of up-front questions, walk away, and return to a decision record they can review, edit, and then hand off to the `linearissue` skill for execution.
+
+## How this fits the broader workflow
+
+```
+prompt
+  │
+  ▼
+designnote skill  →  decision record (with action items in canonical sections)   ← you are here
+  │
+  ▼
+[HITL gate: human reviews, edits, greenlights the record]
+  │
+  ▼
+linearissue       →  proposes tickets in chat → confirms via AskUserQuestion → creates tickets
+  │
+  ▼
+Linear: LIN-NNN annotations written back into the record
+```
+
+This skill produces the artifact that `linearissue` consumes. The two skills share no runtime state — the decision record file is the only interface between them. After `designnote` finishes, the human reviews and edits the record. Only then does `linearissue` read it.
+
+## Context on the artifact
+
+A decision record is a markdown file in `docs/decisions/` following the MADR-style convention:
+
+- **Filename:** `nnnn-kebab-slug.md` where `nnnn` is the next serial number in the directory. Check `ls docs/decisions/ | sort -n | tail -1` before creating. New records start with the next available number.
+- **Front matter:** YAML block with `title`, `tags` (lowercase, kebab-case where multi-word), `status` (`exploring | decided | superseded | deprecated`), `decision` (one-line TL;DR, filled when status becomes `decided`), `review_date` (YYYY-MM-DD), `related_to` (list of serial numbers), `supersedes` (serial number or empty).
+- **Status Log:** table tracking lifecycle transitions with `Status | Date | Author | Related Tickets | Notes`.
+- **Template sections:** `## Context`, `## Exploration`, `## Decision`, `## Consequences`, `## Confirmation`. Records may add custom sections like `## Open Questions`, `## Trigger Points`, `## Action items`, `## Upstream References`, `## Related Design Notes`.
+
+New records start in `status: exploring` with the Decision, Consequences, and Confirmation sections empty or carrying `_No decision yet._`. When the decision is made (HITL), the status transitions to `decided` and those sections are populated.
+
+### Slug generation protocol
+
+The filename slug must be:
+- **Clearly scoped** — captures the core concern, not a vague umbrella term
+- **Reproducible** — different wordings of the same problem should converge on the same slug
+- **General enough to survive reframing** — if the solution pivots, the slug should still apply
+- **Stable** — once created, never renamed (the serial number is the stable reference anyway)
+
+Heuristic: extract the 2–4 most distinguishing nouns/noun-phrases from the problem statement. Drop verbs, articles, and generic qualifiers. Join with hyphens. Examples:
+- "Should we consolidate decisions/ and design-notes/?" → `decisions-dir-consolidation`
+- "Which APM tool should we use?" → `select-apm`
+- "How should we handle .envrc in repos?" → `envrc-template-pattern`
+
+## Tools declared in allowed-tools
+
+- `Task` — spawn parallel subagents for independent web research
+- `WebSearch`, `WebFetch` — direct research from the main agent when needed
+- `AskUserQuestion` — the one-shot batched-clarification tool
+- `Glob`, `Grep`, `Read` — scope discovery across `docs/decisions/**`, `docs/TODO.md`, `CLAUDE.md`
+- `Write`, `Edit` — creating new records and extending existing ones
+- Linear MCP read tools — discovering related tickets and existing Linear docs
+- `mcp__claude_ai_Linear__save_document` — for the strategy/process routing path
+
+The `allowed-tools` declaration pre-approves tool *categories*. For scoped file writes, the user should configure Claude Code settings to pre-approve paths (see **Required grants** at the bottom).
+
+## Phase 0 — Preflight
+
+### Verify repo convention
+
+- `docs/decisions/` exists and is writable. If not, stop and ask: "This repo doesn't have `docs/decisions/`. Bootstrap it from the kb convention, or bail?" Do not silently create the directory.
+- Read the repo's `CLAUDE.md` / `AGENTS.md` at the root for project-specific HITL policies (especially around git and external dependencies).
+- Note whether `docs/TODO.md` exists (it may not — the skill degrades gracefully).
+
+### Permission preflight
+
+Read the Claude Code settings files that may exist (in override order):
+
+1. `~/.claude/settings.json`
+2. `.claude/settings.json` (workspace)
+3. `.claude/settings.local.json` (local override)
+
+Check `permissions.allow` for entries matching `Write(docs/decisions/**)` and `Edit(docs/decisions/**)`. If either grant is missing, warn the user:
+
+> The following permissions are not pre-approved in your Claude Code settings:
+> - `Write(docs/decisions/**)` (needed to create new records)
+> - `Edit(docs/decisions/**)` (needed to extend existing records)
+>
+> Each write will trigger a permission prompt, breaking the walk-away UX.
+>
+> To fix, add to your settings:
+> ```jsonc
+> { "permissions": { "allow": ["Write(docs/decisions/**)", "Edit(docs/decisions/**)"] } }
+> ```
+
+Offer two options via `AskUserQuestion`: **Proceed with prompts** / **Bail — I'll configure first**. If the grants are present, skip this entirely.
+
+### Tool availability
+
+If `WebSearch`, `WebFetch`, `Task`, or the Linear MCP tools are unavailable for policy or environment reasons, degrade gracefully: produce a note based on existing context only, and flag in the Status Log that web/Linear/subagent research was skipped.
+
+## Phase 1 — Interpret and route
+
+Restate the prompt in one or two sentences. Be explicit about the kind of design question it is.
+
+Then apply the **routing test** from the asabina kb framework:
+
+- **Code-adjacent** — architecture, implementation, tech stack, APIs, deployment, testing, tooling, developer experience, data model, security patterns → **repo** (`docs/decisions/`)
+- **Strategy / process / team** — business strategy, positioning, marketing/GTM, team process, product prioritization rationale, cross-project org decisions → **Linear document** (via `save_document`)
+- **Ambiguous** → flag explicitly; ask in Phase 2 rather than silently defaulting
+
+The kb's key test: *"Does this decision affect how code is written, deployed, or maintained?"* → repo. *"Is this about what to build or how to operate as a team?"* → Linear.
+
+Write out the routing decision explicitly in your Phase 4 "locked decisions" commitment so the user can see and override.
+
+### Rename the session
+
+After interpreting the prompt, rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name is a 2–4 word summary of the design topic — e.g. "card layout abstraction (designnote)" or "VID-123 auth token storage (designnote)" if a ticket is related.
+
+If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it — but don't block on this. Move on to scope discovery either way.
+
+## Phase 2 — Scope discovery (parallel, read-only)
+
+Fan out read-only queries to discover what already exists. These can run in parallel:
+
+1. **Tag-based note match.** Grep front matter `tags:` lines across `docs/decisions/**/*.md`. Derive candidate tags from the prompt's semantic core. Find notes whose tags overlap. Respect the **too-general guard** (below).
+2. **Content match.** Grep note titles and bodies for load-bearing keywords from the prompt.
+3. **Linear tickets.** `list_issues` filtered by keyword(s). Capture ticket IDs, titles, state, and project.
+4. **Linear documents** (only if Phase 1 leaned Linear-routed). `list_documents` filtered by keyword(s).
+5. **TODO.md stubs.** Read `docs/TODO.md` and grep for related lines (look for existing stubs that link to design notes).
+6. **Related notes cross-graph.** For each candidate match, check its `## Related Design Notes` section for transitive matches.
+
+### Tag vocabulary handling
+
+- Collect *all* existing tags from front matter across `docs/decisions/**`.
+- Compute frequency per tag.
+- **Too-general guard:** Any tag appearing on more than ~30% of notes is disqualified as a *sole* match. It can still be used, but only when paired with a narrower sibling tag. This keeps discovery actually discoverable.
+- Prefer 2–4 specific tags over 1 general one.
+- Only mint a new tag when no existing tag fits. If minted, log the reason in the Status Log `Notes` column.
+
+## Phase 3 — Batched clarification
+
+Walk the rubric and identify interpretive choices the prompt left open:
+
+- **Match or create** — which existing note (if any) to extend
+- **Routing** — only if Phase 1 was ambiguous
+- **Research depth** — quick (no subagents, current-context only) / medium (2–4 parallel subagent queries) / deep (5+ queries)
+- **Focus** — specific angles to prioritize, or free range
+- **Deliverable shape** — new note from scratch, new section in existing note, extend existing sections, or just a TODO.md line
+
+For each choice: **ask** or **assume**?
+
+- **Ask** only when (a) the answer would materially change the research or output, AND (b) a reasonable default has a real chance of being wrong.
+- **Assume** everything else.
+
+Issue **all questions in a single `AskUserQuestion` call**. Prefer 0–3 questions; **4 is the hard cap**.
+
+If you have zero questions, skip the tool call and write `**No clarification needed — proceeding directly.**` This is the walk-away contract: one interruption max.
+
+### Typical Phase 2 question shapes
+
+- "Which note should I extend (or create new)?" with concrete candidates
+- "Route this to repo or Linear?" with the kb framework's default pre-selected
+- "How deep should the research go?" with quick / medium / deep options
+
+## Phase 4 — Commit to locked decisions
+
+Write out the locked decisions explicitly. Format:
+
+> - **D1 (match):** Extend `0007-card-layout-abstraction-layer.md` — *you chose*
+> - **D2 (routing):** Repo design note — *assumed (code-adjacent)*
+> - **D3 (depth):** Medium — 3 parallel research queries — *assumed*
+> - **D4 (tags):** `layouts`, `abstraction`, `flutter` — *reused from vocabulary*
+> - **D5 (shape):** Add new `## Proposed Solutions` subsections; extend `## Open Questions` — *assumed*
+
+Aim for 4–8 decisions total. **After Phase 4 closes, no more questions for the rest of the run.** Anything that surfaces mid-research goes into the note's `## Open Questions` section, not into a new `AskUserQuestion` call.
+
+## Phase 5 — Research execution
+
+If depth is `quick`, skip to Phase 6.
+
+Otherwise, decompose the research into N independent questions. Spawn N subagents via `Task` with `subagent_type: general-purpose` (or `Explore` for codebase-facing questions). Each subagent receives:
+
+- The locked decisions
+- The relevant Linear/note context the main agent has already gathered, passed as prompt input
+- **One specific research question**
+- Explicit instruction: *return structured findings as a string. Do not write to the filesystem. Do not read or modify any design notes.*
+
+Main agent waits for all subagents, then integrates findings. **Subagents never hold the write lock — the main agent serializes all writes to the note.**
+
+Guidelines:
+
+- **Don't give subagents Linear read tools by default.** Main agent pulls Linear context once and passes it in as prompt input. This avoids each subagent re-querying the same data.
+- **Cross-check load-bearing claims.** Any number, date, attribution, or architectural claim that would drive a recommendation should appear in at least two sources before being stated as fact.
+- **Respect stopping criteria.** Don't over-research. Match depth to Phase 4.
+
+## Phase 6 — Write
+
+Two modes: **create new** or **extend existing**.
+
+### Create new record
+
+1. **Serial number:** Check `ls docs/decisions/ | sort -n | tail -1` to find the highest existing number. Use the next one. Pad to 4 digits (e.g. `0003`).
+2. **Slug:** Apply the slug generation protocol (see above). The filename is `{nnnn}-{slug}.md`.
+3. **Template structure:**
+
+   ```markdown
+   ---
+   title: "Human-Readable Title"
+   tags: [tag1, tag2, tag3]
+   status: exploring
+   decision: ""
+   review_date: YYYY-MM-DD
+   related_to: []
+   supersedes: ""
+   ---
+
+   # Human-Readable Title
+
+   > *Authored by Claude Code.*
+
+   ## Status Log
+
+   | Status | Date       | Author | Related Tickets | Notes                         |
+   | :----- | :--------- | :----- | :-------------- | :---------------------------- |
+   | TODO   | YYYY-MM-DD | claude | [LIN-NNN](...)  | Initial creation via designnote |
+
+   ## Context
+
+   _What is the business or technical context? Why is this worth exploring? What is the scope?_
+
+   ## Exploration
+
+   _What alternatives were considered? What are the trade-offs (pros/cons) of each?_
+
+   ## Decision
+
+   _No decision yet._
+
+   ## Consequences
+
+   _No decision yet._
+
+   ## Confirmation
+
+   _No decision yet._
+   ```
+
+4. **Populate** with findings from the research phase. Add custom sections as needed: `## Open Questions`, `## Trigger Points`, `## Upstream References`, `## Related Design Notes`. Match the richer style of existing records in the repo if they follow one.
+5. **Action items.** If the research surfaces concrete follow-up work, add a `## Action items` section with checklist items. These are the hooks the `linearissue` skill will find later.
+6. **Set `review_date`** to 3 months from today by default. Adjust if the topic is time-sensitive (shorter) or foundational (longer).
+
+### Extend existing record
+
+1. **Read the entire existing record** before touching it.
+2. **Preserve all existing sections verbatim.** Do not rewrite. Do not normalize. Do not reformat.
+3. **Append rather than replace.** New options go into `## Exploration` as new subsections. New questions go into `## Open Questions`. New action items go into `## Action items`. New references go into `## Upstream References`. If a section doesn't exist, add it at the natural location.
+4. **Status Log row.** Append a new row: today's date, `claude` as author, any Linear ticket IDs discovered during research, and a concise note describing the nature of the extension (e.g., "Added Option 4 with performance analysis; raised 2 new open questions").
+5. **Never transition the frontmatter status.** `exploring → decided` and similar are HITL operations. The skill only writes records in `status: exploring`.
+6. **Never rename files.** The serial number is the stable reference. Filenames are permanent.
+
+### Linear doc mode (routing test sent this to Linear)
+
+1. Use `save_document` to create or update a Linear document in the workspace.
+2. Content structure mirrors the repo template adapted for Linear's markdown:
+   - `# Title`
+   - Inline metadata block (tags, date, author) — Linear docs don't support front matter
+   - `## Status Log` table (Linear renders markdown tables)
+   - `## Context` / `## Exploration` / `## Decision` / `## Consequences` / `## Confirmation`
+3. If an existing Linear doc matches (from Phase 2 discovery), update it rather than creating a new one.
+4. Do not write a corresponding file to the repo. This note lives in Linear.
+
+## Phase 7 — Wrap up
+
+Print a concise summary:
+
+- **What was written:** path (or Linear doc URL) and the sections touched
+- **Tags used:** with reuse-or-mint justification for each
+- **Related discovered:** Linear tickets, related notes, TODO.md stubs that informed the work
+- **Open questions captured:** count and pointer to the section
+- **Suggested next step:** e.g., "Review the note, edit as needed, then run `/linearissue` on this path to file tickets from the action items."
+- **Suggested commit message** following the repo's convention (if the repo's `CLAUDE.md` documents one). Include an `[ai:claude]` tag if that's the repo convention. **Do not commit** — git is HITL.
+
+If any research step failed or was skipped (e.g., web unavailable, Linear MCP absent), flag it clearly in both the wrap-up and the note's Status Log.
+
+## Anti-patterns
+
+- **Don't transition frontmatter status.** The `status: exploring → decided` transition is HITL. The skill only creates records in `status: exploring` or extends existing ones.
+- **Don't rename files.** Serial-numbered filenames are permanent. The skill only creates new files or edits existing ones in place.
+- **Don't commit or stage.** All git operations are HITL per the repo's `CLAUDE.md`.
+- **Don't skip scope discovery.** Prefer extending an existing note. Duplication erodes the knowledge base and fragments context.
+- **Don't write from subagents.** Subagents return findings as strings. The main agent holds the write lock on the design note and serializes all writes.
+- **Don't silently mint new tags.** Prefer reuse from the existing vocabulary. Disqualify the too-general tags. If a new tag is necessary, log the reason in the Status Log `Notes` column.
+- **Don't overwrite custom sections when extending.** Preserve exactly what's there. Only append.
+- **Don't write to `ARCHIVE/` directories.** They are historical. Read-only from the skill's perspective.
+- **Don't ask more than one round of clarification.** Phase 3 is the only interruption. Anything that surfaces mid-research goes into the note's `## Open Questions` section and the run continues.
+- **Don't silently fall back to training data.** If web research fails and the prompt requires fresh info, flag it in the Status Log notes column and in the wrap-up.
+- **Don't assume repo conventions.** If `docs/decisions/` doesn't exist, ask the user whether to bootstrap or bail. Don't create the directory silently.
+- **Don't replicate action items elsewhere.** The design note is the single source of truth. No parallel work-plan files, no task list extractions, no duplicate representations. The `linearissue` skill will consume the note directly.
+- **Don't pre-mint ticket IDs.** The note carries action items in plain markdown. Linear IDs are written back by `linearissue` after tickets exist, not before.
+- **Don't interpret "create a design note" as license to create churn.** If an existing note covers the scope, extend it. If a TODO.md one-liner would suffice, just add the line. The warrants-a-note test is: (a) involves a choice with trade-offs, (b) has open questions worth parking, or (c) couples to other architectural concerns. If fewer than one applies, it's probably a TODO.md line.
+
+## Required grants
+
+The skill's `allowed-tools` declaration pre-approves the tool categories it needs. For file writes to be scoped to the decisions directory and TODO.md, configure Claude Code settings (user or workspace) to pre-approve the paths:
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "Write(docs/decisions/**)",
+      "Write(docs/TODO.md)",
+      "Edit(docs/decisions/**)",
+      "Edit(docs/TODO.md)"
+    ]
+  }
+}
+```
+
+Linear MCP tools are declared in `allowed-tools` and should not require per-call approval. The strategy-routing path uses `save_document` which needs Linear write access — same grant.
+
+If these paths aren't pre-approved, the skill will still work but will prompt on each write, breaking the walk-away UX. Configure them before running the skill for the first time.

--- a/skills/linearissue/SKILL.md
+++ b/skills/linearissue/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: linearissue
+description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue, OR when the user wants to create a new issue freeform (without a design note). Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Freeform mode triggers: 'create an issue for X', 'file a ticket about Y', 'new issue: Z', 'ticket this', or any request to create a Linear issue without referencing a design note or existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from records in `status: decided` (decisions are made; they don't spawn tickets — only `status: exploring` records have actionable items), or for any operation that would also commit to git."
+api_description: "File action items from a design note as Linear issues with bidirectional cross-references and idempotent re-runs, iterate on an existing Linear issue by posting analysis, context, or refinements as comments, or create new issues freeform with title quality enforcement. Three modes: filing (from a note), iteration (from a ticket ID or URL), and freeform (from a prompt)."
+allowed-tools: Bash Glob Grep Read Edit WebFetch AskUserQuestion Skill mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__search_pull_requests
+---
+
+# linearissue
+
+Create Linear issues — from a design note's action items, from an existing ticket (iteration), or freeform from a prompt. All modes enforce value-oriented titles via a quality gate, use an in-chat confirmation gate, and support idempotent re-runs.
+
+The defining design principles of this skill are:
+
+> **The design note is the single source of truth. The skill reads it, derives tickets, and writes Linear ticket IDs back into it. No parallel work-plan file. No re-modeling.**
+>
+> **Confirm in chat, not via files.** The skill prints proposed tickets in the conversation, confirms with one `AskUserQuestion`, and creates on approval. One invocation, one session.
+>
+> **Idempotent re-runs.** A note that's already been linearized has inline `Linear: LIN-NNN` annotations. The skill detects them and updates instead of duplicating.
+>
+> **Issues are minimal anchors; comments carry the thinking.** A ticket's title and description are a stable, concise anchor — what the work is, nothing more. Scope crystallization (additions, reductions, pushback, context, reasoning) happens through comments, which are immutable and preserve the history of thinking. Keep descriptions short and pragmatic. Never use them as a context dump from the design note — the backlink to the note is enough. This principle applies in both filing mode and iteration mode.
+
+## How this fits the broader workflow
+
+```
+prompt
+  │
+  ▼
+designnote skill  →  design note (with action items in canonical sections)
+  │
+  ▼
+[HITL gate: human reviews, edits, greenlights the note]
+  │
+  ▼
+linearissue       →  prints proposed tickets in chat
+  │
+  ▼
+[HITL gate: AskUserQuestion confirmation]
+  │
+  ▼
+creates tickets + writes Linear: LIN-NNN annotations back into the note
+```
+
+The human gate on the design note itself is where the real review happens. By the time `linearissue` runs, the note is greenlit — ticket derivation is mechanical. The in-chat confirmation is a final sanity check, not a deep review.
+
+## Tools declared in allowed-tools
+
+- `Glob`, `Grep`, `Read` — discover and parse the design note
+- `Edit` — append cross-references and Status Log rows back to the note
+- `WebFetch` — follow URLs referenced in the note when enriching ticket descriptions
+- `AskUserQuestion` — the confirmation gate (and batched clarification if needed)
+- Linear MCP read tools — search for existing tickets, resolve teams/projects, look up statuses and labels
+- `Skill` — invoke the `commenting` skill for posting comments to Linear issues
+- Linear MCP write tools — `save_issue`
+
+The skill does not declare `Task` — there is no parallel research phase. Ticket derivation is deterministic and serial.
+
+The skill does not declare `Write` — it never creates new files. It only edits the existing design note (appending cross-references and a Status Log row).
+
+## Phase 0 — Preflight
+
+### Parse invocation and detect mode
+
+Examine the first argument (or the full prompt if no explicit argument):
+
+- **Iteration mode** — if the input contains a Linear issue URL (`https://linear.app/...`) or a bare issue identifier matching the pattern `[A-Z]+-\d+` (e.g. `VID-123`, `Z-419`), enter **iteration mode**. Capture the issue ID and the rest of the prompt as the user's intent. Skip to the [Iteration mode](#iteration-mode) section below; do not run the filing-mode phases.
+- **Filing mode** — if the input references a decision record path (explicitly or inferable from `docs/decisions/`), enter **filing mode**. Continue with the filing-mode phases below.
+- **Freeform mode** — if the input is neither a Linear URL/ID nor a design note path — e.g. "create an issue for X", "file a ticket about Y", "new issue: Z", a bare description of work to be ticketed, or a batch of items to file — enter **freeform mode**. Skip to the [Freeform mode](#freeform-mode) section below.
+
+### Rename the session
+
+After detecting the mode, rename the session to reflect the scope:
+
+Rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name reflects the mode and scope — e.g. "card layout abstraction (linearissue)" for filing, "VID-123 OAuth2 Google login (linearissue:iterate)" for iteration, or "auth token storage (linearissue:freeform)" for freeform.
+
+If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it — but don't block on this. Move on to the next phase either way.
+
+### Triage: check for duplicates and scope overlap
+
+Before creating any new issue — whether from a design note or freeform — run a tiered check to avoid duplicates, scope overlap, and contradictions in the backlog. This applies in both filing mode and when other skills (pairprog, freeform conversation) route through `save_issue` to create a ticket.
+
+**Tier 1 — Current work (always run, lightweight):**
+- Check the current branch and the last 2 branches worked on (`git branch --sort=-committerdate | head -3`).
+- Cross-reference with GitHub (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`) to confirm merge state — local state may be stale.
+- If an in-progress branch covers this scope, surface it: "This looks like it fits in VID-XYZ which is still on branch X — want me to fold it in?"
+
+**Tier 2 — Related issues (always run):**
+- If a ticket ID is known (from the branch name, the design note, or the user's prompt), fetch it and check its related issues (`get_issue` with `includeRelations: true`).
+- Scan the related issues for scope overlap or contradictions with the proposed new ticket.
+
+**Tier 3 — Backlog scan (run when the issue is complex or duplicates seem likely):**
+- Search the project backlog (`list_issues` filtered by project and team) for tickets with similar titles or keywords.
+- If matches are found, present them: "These existing tickets look related — should we extend one of them, or is this genuinely new?"
+- Propose resolution: merge scopes, re-prioritize an existing ticket, mark as duplicate, or confirm isolation.
+
+If the triage surfaces a match, present options via `AskUserQuestion`:
+- **Fold into VID-XYZ** — add scope to the existing ticket (comment the new context)
+- **Stack on VID-XYZ** — create as a sub-issue or related issue
+- **Create new** — confirmed isolated, proceed with filing
+- **Cancel** — the user decides to handle it differently
+
+Only proceed to filing after the user confirms the triage result.
+
+### Filing mode: parse invocation
+
+- **Record path** (positional or inferred). If not specified, default to *the most recently modified* file in `docs/decisions/` whose frontmatter `status` is `exploring`. If multiple match, ask in Phase 2.
+- Optional flags: `--team`, `--project` (override note-derived routing).
+
+### Permission preflight
+
+Read the Claude Code settings files that may exist (in override order):
+
+1. `~/.claude/settings.json`
+2. `.claude/settings.json` (workspace)
+3. `.claude/settings.local.json` (local override)
+
+Check `permissions.allow` for entries matching `Edit(docs/decisions/**)`. If the grant is missing, warn the user:
+
+> The `Edit(docs/decisions/**)` permission is not pre-approved in your Claude Code settings. Each write-back to the note will trigger a permission prompt.
+>
+> To fix, add to your settings:
+> ```jsonc
+> { "permissions": { "allow": ["Edit(docs/decisions/**)"] } }
+> ```
+>
+> Proceed anyway, or bail and configure first?
+
+Offer two options via `AskUserQuestion`: **Proceed with prompts** / **Bail — I'll configure first**. If the grant is present, skip this entirely.
+
+### Verify the note
+
+- The path exists and is readable.
+- The frontmatter `status` is `exploring`. If it's `decided`, `superseded`, or `deprecated`, **refuse** with: "This record is in status `{status}`. Settled records are read-only. Did you mean a different one?"
+- The path does not contain `ARCHIVE/`. If it does, refuse for the same reason.
+
+Read the note in full. Read the repo's `CLAUDE.md` / `AGENTS.md` for any project-specific HITL or commit policies.
+
+## Phase 1 — Extract candidate tickets
+
+Parse the note for action items. Canonical sources, in priority order:
+
+1. **`## Action items`** / **`## Action Items`** / **`## Action items when revisiting`** — every checklist item is a candidate
+2. **`## Next Action`** / **`## Next Actions`** — every checklist item or bullet is a candidate
+3. **`## Trigger Points`** / **`## Implementation Timing`** — only items the note explicitly marks as ready to execute (look for "ready", "now", or a checked precondition)
+4. **`## Open Questions`** — only items explicitly tagged for ticketing (e.g., `→ ticket`, `[ticket]`, `[file]`)
+5. **Top-level checklist items `- [ ] ...`** anywhere in the note that are NOT inside a "rejected", "considered", or "Never" section, AND that don't already carry an inline `Linear: LIN-NNN` annotation
+
+For each candidate, capture:
+
+- **Title:** the first line of the item, cleaned up (strip checklist markers, leading "TODO:", trailing punctuation). Run through the **title quality gate** — if the gate fires, store both the original and suggested rewrite for presentation in Phase 3.
+- **Description:** the item's body content + the parent section heading + up to ~10 lines of preceding contextual prose from the section. Quote rather than paraphrase.
+- **Source anchor:** `{relative-note-path}#{slugified-section-heading}` so the Linear ticket can deep-link back.
+- **Tags from the note's front matter** — these may inform Linear labels.
+- **Existing Linear cross-ref:** if the item already has `Linear: LIN-NNN` inline, mark it as "existing — will update, not create".
+
+Skip items that:
+
+- Are already marked complete (`- [x]`)
+- Live inside a `Never`, `Rejected`, `Discarded`, `Out of scope`, or `Superseded` subsection
+- Are inside a fenced code block, table cell, or HTML comment
+- Are in a `<details>` block summarizing rejected approaches
+
+## Phase 2 — Classify, sequence, route
+
+For each candidate:
+
+- **Dependency hints.** Detect "blocked by", "after", "depends on", "requires", "once X is done", or explicit cross-links to other action items. Build a dependency graph. Flag cycles.
+- **Parallel-safety hints.** Only set if the note explicitly mentions file/module scope or parallelism. Otherwise leave unset — don't predict merge-conflict risk you can't actually predict.
+- **Priority hints.** Look for `URGENT`, `P0`/`P1`, `Now/Next/Later/Never` framing, "blocker", "asap". Translate to Linear priority (1=Urgent, 2=High, 3=Normal, 4=Low). Default Normal.
+- **Estimate hints.** Look for `(Effort: S/M/L)` markers from the kb's TODO.md convention. Translate to a numeric estimate if your team uses one. Otherwise leave unset.
+
+**Routing — team and project:**
+
+- If the note's Status Log "Related Tickets" column already references Linear tickets, use the same team/project as those (most recent wins).
+- If the note's front matter or body contains a Linear project link or `team: X` / `project: Y` marker, use that.
+- If `--team` or `--project` flags were passed, use those.
+- Otherwise: include team/project as a question in the confirmation gate (Phase 3).
+
+## Phase 3 — Confirm and create
+
+### Print the proposal
+
+Print a structured summary in chat. This is the reasoning trace — not a file, just chat output:
+
+```
+Proposed tickets from: docs/decisions/{filename}
+Target: {team-key} / {project-name}
+
+ 1. [NEW]    {Title}                          Priority: Normal
+ 2. [NEW]    {Title}                          Priority: High
+             ↳ depends on #1
+ 3. [NEW]    {Title}                          Priority: Normal
+             Suggested: {Rewritten title}  ← title gate fired
+             Warning: mechanism verb 'Implement' leading
+ 4. [UPDATE] {Title} (LIN-123)               Priority: Normal
+             ↳ description changed
+
+Skipped:
+ - "already done thing" — marked complete
+ - "explored option C" — inside Discarded options section
+
+{N} new · {K} updates · {S} skipped
+```
+
+### Confirm
+
+Issue one `AskUserQuestion` call. Combine the confirmation with any unresolved routing questions from Phase 2 into a single batch:
+
+- **Always ask:** "Create these {N} tickets?" with options: **Yes, create all** / **Exclude some — let me pick** / **Bail**
+- **Only if team/project is unresolved:** include a question for team and/or project selection
+- **Only if candidate count is large (>10):** include a question about narrowing scope
+
+If the user chooses "Exclude some", issue one follow-up `AskUserQuestion` with multiSelect listing the candidates so the user can deselect. This is the only case where a second question is permitted.
+
+If the user bails, stop. Print nothing further.
+
+### Create tickets
+
+For each confirmed ticket:
+
+1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), a **DoD** sentence ("Done when X is true/observable/verifiable"), and the source-anchor backlink. The DoD should be concrete enough that someone can check it without reading the full context — e.g. "Done when `/linearissue` activates freeform mode on bare prompts and all titles pass the quality gate." Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
+3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
+4. **Capture** the returned ticket ID and URL.
+
+### Write back to the note
+
+After all `save_issue` calls succeed:
+
+5. **Re-read the note** (in case of any concurrent edits, though unlikely).
+6. **Append `Linear: LIN-NNN` cross-references.** For each newly-created ticket, find the source action item line in the note and append ` (Linear: [LIN-NNN]({url}))` immediately after the item text. For multi-line items, append on a new line indented to the item's level.
+7. **Append a Status Log row** to the note: today's date, `claude` as author, the comma-separated list of created/updated ticket IDs in the Related Tickets column, and a Notes column summary like "Filed N tickets via linearissue (M new, K updated)".
+8. **Save the note** via `Edit`.
+
+### Partial failure
+
+If any `save_issue` call fails partway through:
+
+- Stop the loop. Do not roll back successful tickets.
+- Print which tickets succeeded and which failed.
+- Write back annotations for the items that succeeded, so a re-run picks up where this one left off.
+- Re-running is safe: idempotency on existing IDs prevents duplicates.
+
+### Summary
+
+Print:
+
+- List of created/updated tickets with their URLs
+- Any failures
+- **Suggested commit message** following the repo's convention from `CLAUDE.md` (e.g., `chore(notes): file tickets from {slug} [ai:claude]`). **Do not commit** — git is HITL.
+
+## Iteration mode
+
+Entered when Phase 0 detects a Linear URL or issue ID. The filing-mode phases (1–3) are skipped entirely.
+
+### Load the issue
+
+Fetch in parallel:
+- `get_issue` — title, description, status, labels, priority
+- `list_comments` — full comment thread, ordered by `createdAt`
+
+Print a compact header so the user can confirm you're looking at the right thing:
+
+```
+Iterating on: VID-123 — {title}
+Status: {status} | Priority: {priority}
+{N} comments
+```
+
+### Understand the intent
+
+Read the user's prompt. Classify what they're asking for:
+
+- **Analytical** — "roast this", "what's missing", "does this make sense", "what questions should we answer first" → produce analysis in chat, then offer to post it as a comment
+- **Additive** — "add context about X", "note that we've decided Y" → draft a comment with the new context
+- **Refinement** — "sharpen the description", "the title is off" → propose a new title and/or description (keep it minimal — anchor principle applies)
+- **Mixed** — any combination of the above
+
+For mixed intents, address all of them in a single pass rather than asking for clarification upfront.
+
+### Draft the response
+
+Produce one or both of:
+
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. (Provenance and formatting are handled by the commenting skill — do not add `*[ai:claude-code]*` manually.)
+2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
+
+Print both drafts in chat before asking for confirmation. Make it easy to scan.
+
+### Confirm and write
+
+Issue one `AskUserQuestion` with:
+- **Always:** "Post this comment?" — **Yes** / **Edit first** / **Skip**
+- **Only if an anchor update was drafted:** "Apply the title/description update?" — **Yes** / **Edit first** / **Skip**
+
+Both questions can be batched into a single `AskUserQuestion` call.
+
+On "Edit first": ask what to change, revise, re-present, confirm again.
+
+On approval, write in this order:
+1. `save_issue` for any title/description changes (only if confirmed)
+2. `Skill("commenting", ...)` to delegate the comment to the commenting skill (only if confirmed) — describe the issue ID, comment title (e.g. "Assessment", "Context", "Scope refinement"), the originating skill name ("linearissue"), and the comment body. The commenting skill handles formatting, provenance, and threading.
+
+### Summary
+
+Print:
+- What was posted/updated and the issue URL
+- If nothing was written (user skipped both): note that and stop cleanly
+
+## Freeform mode
+
+Entered when Phase 0 detects neither a Linear URL/ID nor a design note path. This mode creates one or more issues directly from the user's prompt, with full title quality enforcement.
+
+### Parse the request
+
+Read the user's prompt and extract:
+
+- **One or more items to ticket.** The user may describe a single issue ("create a ticket for X") or a batch ("file issues for: A, B, C" or a bulleted list). Each distinct item becomes one ticket.
+- **Context clues** for routing: project mentions, team references, related tickets, priority signals.
+
+For each item, draft:
+
+- **Title** — derive from the user's description, then run through the **title quality gate**. If the gate fires, present the original and suggested rewrite.
+- **Description** — 2–5 sentences maximum: what the work is, why it matters (if not obvious), and a **DoD** sentence ("Done when X is true/observable/verifiable"). Prepend `*[ai:claude-code]*` as the first line. Keep it minimal — the anchor principle applies just as in filing mode.
+- **Priority** — infer from the user's language (urgent, blocker, nice-to-have, etc.). Default Normal.
+- **Labels** — infer from context (e.g. "bug" → Bug label, "research" → Research label). Only apply if confident.
+
+### Triage
+
+Run the same triage check as filing mode (Tier 1–3 from Phase 0) to catch duplicates and scope overlap. If matches are found, present them before proceeding.
+
+### Confirm and create
+
+Print a structured proposal, similar to filing mode:
+
+```
+Proposed issues (freeform)
+Target: {team-key} / {project-name}
+
+ 1. [NEW]  {Title}                          Priority: Normal
+           {2-line description preview}
+ 2. [NEW]  {Title}                          Priority: High
+           {2-line description preview}
+
+{N} new issues
+```
+
+If any title triggered the quality gate, show both versions:
+
+```
+ 1. [NEW]  {Original title}                 Priority: Normal
+           Suggested: {Rewritten title}  ← value-oriented
+           Warning: mechanism verb 'Implement' leading
+```
+
+Issue one `AskUserQuestion`: "Create these {N} issues?" with options: **Yes, create all** / **Exclude some** / **Edit titles** / **Bail**
+
+- **Edit titles** — the user provides corrections; revise and re-present.
+- **Exclude some** — one follow-up `AskUserQuestion` with multiSelect.
+
+### Create tickets
+
+For each confirmed ticket, call `save_issue` with team, project, title, description, priority, and labels. The same rules as filing mode apply:
+
+- Descriptions are minimal anchors (2–4 sentences max)
+- Prepend `*[ai:claude-code]*` to the description
+- If extra context is needed beyond the anchor, post it as a comment after creation via the commenting skill
+
+### Summary
+
+Print:
+
+- List of created tickets with their URLs
+- Any failures
+- No commit suggestion — freeform mode doesn't touch files
+
+### Differences from filing mode
+
+| | Filing mode | Freeform mode |
+|---|---|---|
+| Source | Design note file | User's prompt |
+| Write-back | Inline `Linear: LIN-NNN` annotations in the note | None — no file to annotate |
+| Status Log | Appended to the note | None |
+| Commit suggestion | Yes (note was modified) | No (no files touched) |
+| Title derivation | From action item text | From user's description |
+| Title quality gate | Applied | Applied |
+| Triage | Applied | Applied |
+
+## Title quality gate
+
+Every title — whether derived from a design note action item, drafted in freeform mode, or proposed as an iteration refinement — must pass through this gate. The gate is **advisory**: warn and suggest, never block.
+
+### Principles
+
+1. **Value over mechanism** — frame what the issue delivers, not how it's implemented. "Stable room link for live AV" not "Implement re-entrancy for Daily transport". The title should answer "what changes for the user/system?" not "what code do we write?".
+2. **Distinguishing phrase first** — the most identifiable words lead. Linear branch names truncate after ~25 chars past the ticket prefix, so front-loaded meaning survives truncation.
+3. **Brevity** — keep titles under 72 characters. Warn above 72. Shorter is almost always better.
+4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
+5. **Branch-name-friendly** — avoid special characters, deep nesting, or parenthetical lists that produce ugly slugs.
+
+### Anti-patterns to detect
+
+- **Mechanism verbs leading** — "Wire up", "Implement", "Add", "Decouple", "Compose", "Inject", "Conduct", "Redesign", "Create", "Build", "Set up" as the first word. Exception: action verbs describing user-facing behavior are fine ("Allow bot to interrupt", "Select auth provider").
+- **Bracket tags** — `[Research]`, `[Spike]`, `[WIP]`, `[Bug]` waste leading characters. Use Linear labels.
+- **"Explore/Research/Spike:" prefixes** — metadata that belongs in labels.
+- **Parenthetical lists** — "(Meet, Zoom, WhatsApp)" or "(bioguide_id, thomas_id)" add precision but kill readability. Use slash-separated inline: "Bot joins Meet/Zoom/WhatsApp calls".
+- **Question-format titles** — "Does X expose Y?" belongs in the description.
+- **Kitchen-sink titles** — "Improve X — reduce Y and explore Z" tries to do too much in one title.
+- **Technical-identifier-first** — "bioguide_id mapping for member identity" buries the value. Prefer "Member identity resolver" or "Resolve member identity from bioguide".
+- **Redundant context** — "linearissue skill: value-oriented titles + freeform creation mode" — the project/component prefix is redundant when the ticket already has a project and labels.
+
+### When the gate fires
+
+If any issues are detected, draft a suggested rewrite alongside the original. Present both in the confirmation step so the user can choose:
+
+```
+Title:     <original title>
+Suggested: <rewritten title>  ← value-oriented, distinguishing phrase first
+Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 chars (>72)">
+```
+
+### Examples (before → after)
+
+- "Implement member identity resolver (bioguide_id mapping)" → "Member identity resolver"
+- "Create ticker identity resolver (security master)" → "Ticker identity from security master"
+- "Add CI job for agents test suite" → "CI for agents test suite"
+- "Set up authentication token storage mechanism" → "Auth token storage"
+- "Wire up Logfire for APM and distributed tracing" → "Logfire APM and tracing"
+- "Explore service-level hooks for production frame-level observability" → "Production frame-level o11y hooks"
+- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Bot joins Meet/Zoom/WhatsApp calls"
+
+### Titles that pass (no rewrite needed)
+
+- "Select auth provider" — short, clear, distinguishing
+- "Optimise for showtime" — punchy, value obvious
+- "Allow bot to interrupt" — user-facing behavior, 4 words
+- "Uncensor STT input" — brief, clear what it delivers
+- "Graceful LLM fallback on provider outage" — value-first, concise
+
+## Anti-patterns
+
+- **Don't run on `decided`/`superseded`/`deprecated` records** or anything in `ARCHIVE/`. Settled records are read-only.
+- **Don't run on Linear documents.** This skill operates on repo-local `docs/decisions/**` files. Linear-routed records (from `designnote`'s strategy path) are not in scope.
+- **Don't transition frontmatter status.** Status transitions (`exploring → decided`) are HITL. Don't rename files either — serial-numbered filenames are permanent.
+- **Don't commit or stage.** All git operations are HITL per the repo's `CLAUDE.md`.
+- **Don't overwrite existing `Linear: LIN-NNN` annotations.** If present, the item is already ticketed; treat as update or skip, never re-create.
+- **Don't expand the note's substantive content.** The only writes the skill makes to the source note are: (a) inline `Linear: LIN-NNN` cross-references on action items, and (b) one new Status Log row. Do not edit any other text in the note.
+- **Don't create new files.** The note itself is the only file touched.
+- **Don't interpret non-canonical sections creatively.** Only known sections and explicit `→ ticket` markers count. If a note has work in a non-canonical section, ask in Phase 3.
+- **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
+- **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way.
+- **Don't over-fill descriptions.** A description is a minimal anchor — 2–5 sentences max (what, why, DoD, backlink). Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
+- **Don't skip the DoD.** Every ticket needs a "Done when..." sentence in the description. It should be concrete and verifiable — not "done when implemented" but "done when X is observable/testable." If the source material doesn't imply a clear DoD, draft one from the action item's intent and surface it in the confirmation gate for the user to refine.
+- **Don't default to description updates in iteration mode.** The user's intent is almost always to add a comment. Only propose a title/description change when the prompt explicitly targets the anchor (e.g. "the title is wrong", "rewrite the description"). When in doubt, put it in a comment.
+- **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
+- **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
+- **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
+- **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
+
+## Required grants
+
+The skill's `allowed-tools` declaration pre-approves the tool categories. For scoped edits to design notes, configure Claude Code settings:
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "Edit(docs/decisions/**)"
+    ]
+  }
+}
+```
+
+The skill checks for this grant in Phase 0 and warns if it's missing.
+
+Linear MCP write tool (`save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("commenting", ...)`, which requires the `Skill` tool to be allowed so the commenting skill can be invoked.

--- a/skills/pairprog/SKILL.md
+++ b/skills/pairprog/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: pairprog
+description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
+api_description: "Pair-program on a Linear ticket: explore the codebase, assess unknowns, spike on feasibility, plan atomic steps, and implement with frequent HITL checkpoints. Posts assessments, spike findings, and progress back to the Linear ticket. Human commits each step; AI drives."
+allowed-tools: Bash Glob Grep Read Write Edit Task Skill AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
+---
+
+# pairprog
+
+Pair-program on a ticket. **You drive, the human navigates.**
+
+This skill is the opposite of walk-away. The human is at the keyboard, engaged, steering. You write the code, explain your thinking, surface decisions, and check in frequently. The rhythm is: explore → plan → check in → implement a step → check in → repeat.
+
+The defining design principles are:
+
+> **Driver/navigator dynamic.** You drive (write code, run exploration, propose changes). The human navigates (steers direction, makes judgment calls, approves changes, commits). Neither works alone.
+>
+> **Derisk first.** Before writing production code, identify what's uncertain and spike on it. Feasibility unknowns resolved early prevent wasted work late.
+>
+> **Atomic steps with checkpoints.** Each change is small enough to steer in one pass. The human sees the change, gives design feedback, and the session continues. Checkpoints are for steering, not code review.
+>
+> **PR-always.** Code review happens on GitHub, not in the CLI chat. Every session that produces code ends with a PR. GitHub has line comments, a mobile app, and formal review flows — it's a better review surface than chat. If a PR turns out wrong, close it or drop commits — PRs are cheap.
+>
+> **Parallel where possible.** Use subagents for independent exploration and implementation tasks. Don't serialize work that can run concurrently. But always reconvene with the navigator before acting on findings.
+>
+> **Comment everything back to the ticket.** Assessments, spike findings, plans, and step completions are posted as Linear comments. This means a cancelled session can be picked up later — the ticket carries the full context.
+
+**Commenting protocol.** All Linear comments are posted via the `commenting` skill (`Skill("commenting", ...)`). Pairprog describes what to comment; the commenting skill handles formatting, provenance, and threading. Store anchor comment IDs returned by the commenting skill to thread subsequent replies.
+
+## Commit modes
+
+The skill supports two commit modes. The navigator can switch between them at any time during the session. A typical pattern on non-trivial work: start in checkpoint to refine the design through implementation, then switch to yolo once the remaining work is known and trivial.
+
+- **Checkpoint mode:** The skill presents each atomic change and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
+- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation. The navigator can interrupt at any time to steer.
+
+**Milestone file commit gate.** A `PostToolUse` hook monitors edits to milestone files (package manifests, lock files, flake.nix, etc.). When you see a `CHECKPOINT:` message from this hook, you **MUST** immediately:
+1. Stop implementation work
+2. Present the milestone file change to the navigator with a summary of what was added/changed
+3. Wait for the navigator to commit (checkpoint mode) or auto-commit immediately (yolo mode)
+4. Only then proceed to the next implementation step
+
+This prevents atomic steps (like adding a dependency) from being tangled with subsequent implementation changes in the same uncommitted working tree. The hook fires on: package.json, package-lock.json, pnpm-lock.yaml, yarn.lock, Cargo.toml, Cargo.lock, flake.nix, flake.lock, pyproject.toml, poetry.lock, uv.lock, go.mod, go.sum, Gemfile, Gemfile.lock, mix.exs, mix.lock, and *.cabal files.
+
+**System-scope commands are always HITL, even in yolo mode.** Commands that modify system state (`brew install`, `npm install -g`, `pip install`, `cargo install`, etc.) are never auto-approved. When a tool is missing, surface it to the navigator with context (e.g. "gitleaks is required by the pre-commit hook — install via `nix develop` or approve `brew install gitleaks`?") rather than resolving it silently. Imperative installs bypass version control and can't be reviewed or rolled back.
+
+At the start of the session, if the skill detects this is a fresh ticket with no prior work, ask:
+
+> "Checkpoint or yolo? (You can switch anytime.)"
+
+Default to **checkpoint** for non-trivial work (multiple steps, unknowns). Default to **yolo** for simple/mechanical work (adding a package, small config change). If prior work exists on the branch, default to checkpoint without asking (the navigator is resuming deliberate work).
+
+**Important:** In both modes, code review happens via PR on GitHub — not in the CLI chat. Checkpoints are for design steering, not line-by-line code review. When the navigator wants to review code, offer to prep a PR: "Shall I ship a PR so you can review on GitHub?"
+
+## Phase 0 — Pick up the ticket
+
+### Identify the work
+
+Determine what ticket to work on, in this order:
+
+1. **Explicit argument** — if the user passed a ticket ID (`LIN-123`, `Z-123`) or branch name, use that.
+2. **Current branch** — run `git branch --show-current`. If the branch name contains a ticket identifier (e.g., `vidbina/z-123-some-description`), extract it.
+3. **Ask** — if neither yields a ticket, ask the user what to work on.
+
+### Check out the branch
+
+If the ticket has a git branch name (from the Linear issue's `branchName` field or inferred from the ticket ID), and that branch is not currently checked out:
+
+- Run `git fetch` to ensure the branch is available locally.
+- Run `git checkout {branch}` to switch to it.
+- If the branch doesn't exist yet, determine the correct base before asking:
+  - If the ticket is a sub-issue, check whether the parent ticket has a branch. If it does, that branch is the base — branching from `main` would break the stack's mergeability.
+  - If the ticket is top-level, default to `main` — but check whether there is an in-progress stack (e.g. a series of open PRs targeting each other) that this work should continue. If a stack exists, ask the navigator whether to extend it or start fresh from `main`.
+  - Ask: "No branch for this ticket yet. Create `{suggested-branch-name}` from `{base}`?" naming the resolved base explicitly. On approval, create and check out.
+
+If the user passed a branch name directly rather than a ticket ID, check it out if not already on it.
+
+### Load context (parallel)
+
+Once the ticket ID is known and the branch is checked out, fetch all of these in parallel:
+
+- **Linear ticket:** `get_issue` with the ticket ID. Capture title, description, state, priority, labels, project, parent issue.
+- **Linear comments:** `list_comments` — read existing comments. If a previous pairprog session left assessment/plan/spike comments, note them. This is the resumption path.
+- **Branch state:** `git log --oneline -10`, `git status`, `git diff main...HEAD` (or appropriate base branch) to understand what's already been done on this branch.
+- **Codebase orientation:** Use `Task` with `subagent_type: Explore` to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
+- **Repo conventions:** Read `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` at the repo root for development workflow, testing, and quality requirements.
+
+### Branch fit check
+
+After loading context, compare the files the planned work will touch against the branch's stated purpose (derived from the ticket title/description and existing commits on the branch). Classify any mismatches:
+
+**Category A — Opportunistic feature/code work (scope creep)**
+
+Detected when a planned change touches files unrelated to the current branch's purpose (e.g. fixing an unrelated bug, adding a feature that belongs on a different ticket).
+
+- **Checkpoint mode:** Surface to the navigator before doing anything. Present three options via `AskUserQuestion`: (a) continue on the current branch, (b) navigator cuts a new branch, (c) file a ticket and defer. Wait for the answer before proceeding.
+- **Yolo mode:** Create a local `tmp/<slugified-title>` branch and continue work there. Do **not** push it. At session wrap-up, surface it: "I branched off `tmp/<slug>` for this out-of-scope work — file a ticket and rename it, or drop it?" On drop: run `git branch -D tmp/<slug>` and log what was discarded.
+
+Guards: never push a `tmp/` branch. Never cut a named branch or file a ticket autonomously — both are HITL actions.
+
+**Category B — Agent meta-corrections**
+
+Detected when the navigator corrects agent behaviour mid-session and the fix touches `AGENTS.md`, `CONTRIBUTING.md`, or skill files in the repo (e.g. `claude/skills/**`).
+
+- Do it in place on the current branch. No escalation needed — the correction request is the approval.
+- Isolate in its own commit with a `docs(agents):` or `docs(contributing):` subject so the PR diff shows the mixing explicitly.
+
+**Why the distinction matters:** Category B corrections must take effect immediately — deferring them to another branch means working with broken instructions for the rest of the session. Category A has no such urgency and should always be routed properly.
+
+If no mismatch is detected, proceed without comment.
+
+### Transition to In Progress
+
+After the branch is checked out and the ticket is loaded, call `save_issue` with `id: {ticket-id}` and `state: "In Progress"`. Do this unconditionally — picking up the branch is the signal that work has started. No comment needed; the state change speaks for itself.
+
+### Rename the session
+
+After the ticket is loaded, rename the session so the user can identify it at a glance (e.g. in a terminal tab or session list). A good name includes the ticket number and a 2–4 word summary — e.g. "VID-662 rename titles (pairprog)".
+
+If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it themselves — but don't block on this. It's a nice-to-have, not a gate. Move on to the next phase either way.
+
+At major phase transitions, the session name ideally updates to reflect the current phase (assess, plan, exec, wrapup). Again, suggest if possible but don't block.
+
+### Present the ticket
+
+Print a compact summary:
+
+```
+Ticket: Z-123 — Add OAuth2 support for Google login
+Status: In Progress | Priority: High | Project: Auth
+Branch: vidbina/z-123-add-oauth2-google-login (3 commits ahead of main)
+
+Description:
+> [Quoted ticket description, trimmed to essentials]
+
+Prior session context (from comments):
+> [If previous pairprog comments exist, summarize what was assessed/planned/completed]
+
+Branch work so far:
+> [Summary of existing commits on this branch, if any]
+```
+
+If prior pairprog comments indicate the session was interrupted, note what was completed and what remains.
+
+## Phase 1 — Assess and derisk
+
+### Identify unknowns
+
+Read the ticket and existing branch work. Categorize what remains:
+
+- **Clear and ready** — requirements are unambiguous, implementation path is known, can start immediately.
+- **Unclear requirements** — the ticket is vague or contradictory on what exactly to build. Needs navigator input.
+- **Feasibility unknowns** — "can we even do X?" questions. These need a spike before committing to an approach.
+- **Dependency unknowns** — blocked by something external (API availability, another PR, a library feature). Needs investigation.
+
+### Comment the assessment to Linear
+
+Post the assessment as an anchor comment via the commenting skill. Include the categorized unknowns (Clear and ready / Unclear / Feasibility unknowns / Blocked) as the body content:
+
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Assessment\" from skill \"pairprog\" with body:
+
+**Clear and ready:**
+- Add Google OAuth callback endpoint
+- Store refresh tokens in existing session table
+
+**Unclear — need navigator input:**
+- Token expiry handling — ticket says \"handle gracefully\" but doesn't specify
+- Scope of Google permissions — email only, or also profile?
+
+**Feasibility unknowns — spiking:**
+- Google OAuth library compatibility with our Node version
+- Session table schema — can we store tokens without a migration?
+
+**Blocked:**
+- (none)")
+```
+
+Store the returned anchor comment ID — spike findings and other assessment follow-ups thread under it.
+
+### Spike on feasibility (parallel)
+
+For each feasibility unknown, spawn a `Task` subagent to investigate:
+
+- Read relevant source code, docs, or external references
+- Try small proof-of-concept explorations (read-only or in scratch space)
+- Return a structured answer: feasible / not feasible / feasible with caveats
+
+Subagents are read-only investigators. They don't write production code.
+
+**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings anchor per spike after the subagent returns, via the commenting skill:
+
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Spike: Google OAuth library compatibility\" from skill \"pairprog\" with body:
+
+**Verdict:** Feasible ✓
+
+`@googleapis/google-auth-library` v9.x supports Node 18+. Tested import resolution
+against our `tsconfig.json` paths — no conflicts. The `OAuth2Client` class exposes
+`getToken()` and `refreshToken()` which map directly to our needs.
+
+Relevant code: `src/config/auth.ts` already has a provider pattern we can extend.")
+```
+
+### Check in with the navigator
+
+Present findings to the human:
+
+```
+Ready to implement:
+ 1. Add Google OAuth callback endpoint
+ 2. Store refresh tokens in existing session table
+
+Need your input:
+ 3. Token expiry handling — ticket says "handle gracefully" but doesn't specify.
+    Options: (a) silent refresh, (b) redirect to login, (c) both with fallback
+ 4. Scope of Google permissions — email only, or also profile?
+
+Spiked and resolved:
+ 5. Google OAuth library — compatible ✓ (see ticket comment)
+ 6. Session table schema — can use metadata JSONB column ✓ (see ticket comment)
+
+Blocked:
+ (none)
+```
+
+Use `AskUserQuestion` for the items that need input. In pair programming, asking questions as they arise is expected. Batch questions that are ready at the same time rather than asking them one by one.
+
+## Phase 2 — Plan the work
+
+### Break into atomic steps
+
+Each step should be:
+
+- **Reviewable in isolation** — a human can read the diff and understand the intent
+- **Testable** — either via existing tests, a new test, or manual verification
+- **Committable** — it doesn't leave the codebase in a broken state
+
+### Identify parallelism
+
+Mark which steps are independent and can be worked on by concurrent subagents. Typical parallel opportunities:
+
+- Tests for different modules
+- Implementation of independent functions/components
+- Documentation updates alongside code changes
+
+### Present the plan
+
+```
+Plan for Z-123 — Add OAuth2 support for Google login
+
+Step 1: Add Google OAuth callback route
+  Files: src/routes/auth.ts, src/config/oauth.ts (new)
+  Test: src/routes/__tests__/auth.test.ts
+
+Step 2: Token storage in session metadata    ← parallel with Step 3
+  Files: src/services/session.ts
+  Test: src/services/__tests__/session.test.ts
+
+Step 3: Silent token refresh middleware       ← parallel with Step 2
+  Files: src/middleware/auth.ts
+  Test: src/middleware/__tests__/auth.test.ts
+
+Step 4: Update login UI with Google button   ← after Steps 1-3
+  Files: src/components/LoginForm.tsx
+  Test: manual verification
+
+Ready to start?
+```
+
+Wait for the navigator's approval or adjustment before proceeding.
+
+### Comment the plan to Linear
+
+After the navigator approves (or adjusts) the plan, post it as an anchor comment via the commenting skill:
+
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Plan\" from skill \"pairprog\" with body:
+
+- [ ] Step 1: Add Google OAuth callback route
+- [ ] Step 2: Token storage in session metadata (parallel with 3)
+- [ ] Step 3: Silent token refresh middleware (parallel with 2)
+- [ ] Step 4: Update login UI with Google button (after 1-3)")
+```
+
+Store the returned plan anchor comment ID — all step completions and mid-session adaptations thread under it. This checklist serves as the resumption point if the session is interrupted.
+
+## Phase 3 — Execute
+
+### Work through the plan
+
+For each step:
+
+1. **Announce** what you're about to do. "Starting Step 1 — adding the OAuth callback route."
+2. **Branch fit check.** Before touching any files, verify this step's files fit the branch purpose. Apply the Category A / Category B protocols from the Phase 0 branch fit check if a mismatch is detected.
+3. **Implement** the change. Use `Edit` / `Write` for code changes.
+4. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
+5. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
+6. **Checkpoint.**
+   - **Checkpoint mode:** Pause for the navigator's steering input. This is about design direction — does this approach hold up? Should we change course? If the navigator says "looks good," they commit. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
+   - **Yolo mode:** Invoke the `commitmsg` skill's methodology (read repo convention, draft message) and auto-commit. Print the commit hash and message. Continue to the next step.
+
+   **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.
+
+### Comment step completions to Linear
+
+After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a reply threaded under the plan anchor via the commenting skill:
+
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"Step 1 complete\" from skill \"pairprog\" with body:
+
+Added Google OAuth callback route in `src/routes/auth.ts` and `src/config/oauth.ts`.
+Test added in `src/routes/__tests__/auth.test.ts` — passing.
+
+Commit: `a1b2c3d`")
+```
+
+### Parallel execution
+
+When the plan has independent steps, use `Task` subagents to work on them concurrently:
+
+- Each subagent receives the full plan context and its assigned step
+- Each subagent writes its changes and runs its tests
+- When both complete, present the combined results to the navigator
+- Each step is committed separately (atomic commits) — in checkpoint mode the navigator reviews each; in yolo mode both auto-commit
+
+After parallel subagents complete, post one combined comment to keep the thread focused rather than interleaving.
+
+### Adapting mid-session
+
+Pair programming is fluid. The plan from Phase 2 is a starting point, not a contract. If the navigator wants to:
+
+- Reprioritize steps → adjust the order
+- Add a step → insert it
+- Skip a step → skip it
+- Change approach entirely → re-plan from Phase 2
+
+Accommodate without friction. The navigator steers.
+
+When mid-session adaptation happens, post the change as a reply to the plan anchor via the commenting skill. Use the appropriate emoji prefix in the title:
+
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"🚨 Plan adjusted\" from skill \"pairprog\" with body:
+
+Step 3 (Silent token refresh middleware) replaced with:
+Step 3a: Explicit re-login flow on token expiry
+
+Reason: Navigator decided silent refresh adds complexity without clear UX benefit.")
+```
+
+Use these emojis for mid-session events:
+- 🚨 — plan change (step reordered, replaced, or approach changed)
+- ⏭️ — step skipped
+- 🌟 — step added
+- 🚧 — blocker discovered mid-implementation
+- ⚠️ — conflict between plan and reality (code doesn't behave as expected, API doesn't work as documented, etc.)
+
+## Phase 4 — Wrap up
+
+When all steps are implemented (or the session ends naturally):
+
+### Summary
+
+Print what was accomplished:
+
+- What was implemented, what tests were added/updated
+- What's left (if anything) and whether it needs a follow-up session or more design
+- Any blockers or open questions that surfaced during implementation
+
+### Commit threshold
+
+If there are uncommitted changes (checkpoint mode only):
+
+- Use the `commitmsg` skill to generate messages for any uncommitted work
+- If multiple logical changes are uncommitted, suggest breaking them into separate commits and provide a message for each
+- The navigator decides what to stage and commit
+
+### PR creation
+
+If the branch looks complete relative to the ticket scope, **delegate to the `/pr` skill.** Do not duplicate PR creation logic here — invoke it via the `Skill` tool with `skill: "pr"`.
+
+The `/pr` skill handles: base branch detection (including stacked PRs), drafting the title and body from commits and the Linear ticket, pitching in chat for approval, pushing, creating via `gh`, transitioning the ticket to In Review, and launching a background CI monitor.
+
+If the navigator says "not yet" or "more work needed," skip. The navigator will create it when ready.
+
+### Comment wrap-up to Linear
+
+Post a final session summary as a resolution reply to the plan anchor via the commenting skill:
+
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"✅ Session complete\" from skill \"pairprog\" with body:
+
+**Completed:**
+- [x] Step 1: OAuth callback route
+- [x] Step 2: Token storage
+- [x] Step 3a: Explicit re-login flow
+- [x] Step 4: Login UI with Google button
+
+**Remaining:**
+- (none — PR created: #47)
+
+**Commits:** a1b2c3d, d4e5f6a, b7c8d9e, f0a1b2c")
+```
+
+## Anti-patterns
+
+- **Don't work silently for long stretches.** This is pairing, not autonomous mode. Check in after each atomic step. If exploration takes a while, print progress notes.
+- **Don't commit in checkpoint mode.** All git write operations are HITL unless the navigator explicitly switched to yolo mode.
+- **Don't skip the derisk phase.** Feasibility unknowns caught early save time. Don't jump to implementation because "it's probably fine."
+- **Don't serialize parallelizable work.** If two steps are independent, use subagents. The navigator's time is valuable.
+- **Don't make large changes without checkpoints.** If a step turns out bigger than expected, break it down further and checkpoint mid-step.
+- **Don't assume the plan is fixed.** The navigator can redirect at any checkpoint. Accommodate without pushback.
+- **Don't ask trivial questions.** The navigator is engaged but shouldn't be pestered. Ask about direction and judgment calls, not about syntax or obvious implementation details.
+- **Don't ignore the repo's quality gates.** If the repo has lint/test/typecheck commands in CLAUDE.md or README, run them before presenting a change.
+- **Don't touch unrelated code.** Stay within the scope of the ticket. If you notice unrelated issues, mention them verbally — don't fix them unless the navigator asks.
+- **Don't post "starting spike" comments.** Wait for the spike to complete, then post findings. One comment per spike, not a running log.
+- **Don't interleave parallel step comments.** When subagents work concurrently, post one combined comment after both complete.
+- **Don't create PRs without pitching first.** Always show the proposed PR content in chat and get explicit approval before running `gh pr create`.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: pr
+description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pairprog, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via the GitHub MCP on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
+allowed-tools: Bash Glob Grep Read Agent AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__github__create_pull_request mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__merge_pull_request mcp__github__update_pull_request mcp__github__search_repositories mcp__github__get_file_contents mcp__github__list_branches
+---
+
+# pr
+
+Create a pull request. **Fast, good defaults, operator confirms before anything is created.**
+
+The defining design principles:
+
+> **DX-first.** Derive as much as possible automatically — base branch, title, body. The operator should need to type as little as possible.
+>
+> **Pitch before creating.** Always show the full draft in chat and get explicit approval. Never run `gh pr create` without confirmation.
+>
+> **Smart base for stacked PRs.** If the branch was cut from another feature branch (not main), use that branch as the base. Merging a stacked PR into main loses the stack structure.
+
+## Phase 1 — Gather context
+
+Run in parallel:
+
+- **Branch:** `git branch --show-current`
+- **Commits on branch:** `git log --oneline main..HEAD` (or `git log --oneline HEAD ^origin/main` if on remote)
+- **Push state:** `git status -sb` — is the branch already pushed to origin?
+- **Remote default branch:** use `mcp__github__get_file_contents` or `mcp__github__list_branches` to determine the default branch — don't hardcode `main`
+
+Extract a ticket ID from the branch name if present (e.g. `vidbina/vid-123-some-slug` → `VID-123`). If found, fetch the Linear issue (`get_issue`) for title and description.
+
+### Rename the session
+
+After context is gathered, rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name includes the ticket number and a 2–4 word summary — e.g. "VID-662 rename titles (pr)".
+
+If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it — but don't block on this. Move on to drafting either way.
+
+## Phase 2 — Detect base branch
+
+Find the correct base using this algorithm:
+
+```bash
+# All local branches that are ancestors of HEAD, ranked by closeness
+git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | grep -v "$(git branch --show-current)" \
+  | while read b; do
+      if git merge-base --is-ancestor "$b" HEAD 2>/dev/null; then
+        count=$(git log --oneline "$b"..HEAD | wc -l | tr -d ' ')
+        echo "$count $b"
+      fi
+    done \
+  | sort -n \
+  | head -5
+```
+
+The branch with the **fewest commits between its tip and HEAD** is the most likely parent.
+
+**Decision rules:**
+- If the closest ancestor is the default branch (e.g. `main`) → normal PR, base = default branch.
+- If the closest ancestor is another feature branch → stacked PR, base = that feature branch. Flag this clearly in the pitch: "This looks like a stacked PR — base set to `<parent-branch>`."
+- If ambiguous (tie or no clear parent), default to the repo's default branch and note the ambiguity.
+
+## Phase 3 — Draft
+
+**Title:**
+1. Use the Linear ticket title if available.
+2. Otherwise, derive from the branch name slug (strip the owner prefix and ticket ID, humanize the remainder).
+3. Run the title through the **title quality gate** below.
+
+### Title quality gate
+
+Evaluate the drafted title against these criteria. The gate is **advisory** — warn and suggest, never block.
+
+**Principles:**
+1. **Value over mechanism** — frame what the PR delivers, not how it's implemented. "Stable room link for live AV" not "Implement re-entrancy for Daily transport".
+2. **Distinguishing phrase first** — the most identifiable words lead, so truncated branch names (`~25 chars` after the ticket prefix) stay meaningful.
+3. **Brevity** — keep titles under 60 characters. Warn above 60.
+4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
+
+**Anti-patterns to detect:**
+- **Mechanism verbs leading** — "Wire up", "Implement", "Add", "Decouple", "Compose", "Inject", "Conduct", "Redesign" as the first word describe implementation, not value. Exception: action verbs that describe user-facing behavior are fine ("Allow bot to interrupt").
+- **Bracket tags** — `[Research]`, `[Spike]`, `[WIP]` waste leading characters. Use labels instead.
+- **"Explore/Research/Spike:" prefixes** — front-load metadata that belongs in labels.
+- **"Draft design note:" prefixes** — the work type is obvious from context.
+- **"Fix broken..." with mechanism** — "Fix broken X — replace Y with Z" buries the value. Prefer "X works again" or name the symptom.
+- **Parenthetical lists** — "(Meet, Zoom, WhatsApp)" or "(Cartesia disconnect, room leave)" add precision but kill branch readability.
+- **Question-format titles** — "Does X expose Y?" belongs in the description.
+- **Kitchen-sink titles** — "Improve X — reduce Y and explore Z" tries to do too much in one title.
+
+**When the gate fires:**
+
+If any issues are detected, draft a suggested rewrite alongside the original. Present both in the Phase 4 pitch so the operator can choose:
+
+```
+Title:     <original title>
+Suggested: <rewritten title>  ← value-oriented, distinguishing phrase first
+Warning:   <what triggered the gate — e.g. "mechanism verb 'Implement' leading", "67 chars (>60)">
+```
+
+**Examples (before → after):**
+- "Wire up Logfire for APM and distributed tracing" → "Logfire APM and tracing"
+- "Implement e2e tests: HTTP contract and Daily room verification" → "E2e tests for /connect and Daily"
+- "Explore service-level hooks for production frame-level observability" → "Production frame-level o11y hooks"
+- "Decouple FilterSink frame-type routing from pipecat string class names" → "Decouple frame routing from pipecat"
+- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Bot joins Meet/Zoom/WhatsApp calls"
+- "Graceful LLM provider fallback when primary flakes" → "LLM fallback on provider outage"
+
+**Titles that pass (no rewrite needed):**
+- "Select auth provider" — short, clear, distinguishing
+- "Optimise for showtime" — punchy, value obvious
+- "Allow bot to interrupt" — user-facing behavior, 4 words
+- "Uncensor STT input" — brief, clear what it delivers
+
+**Body:**
+```markdown
+## Summary
+<2-4 bullet points — what changed and why, derived from commits and ticket description>
+
+## Test plan
+<bullet checklist of how to verify the change>
+
+<Linear ticket link if available>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Derive the summary from commit messages and the Linear ticket description. Derive the test plan from the nature of the changes (e.g. "run tests", "manually verify X flow", "check CI passes").
+
+## Phase 4 — Pitch in chat
+
+Print the full draft before doing anything:
+
+```
+PR draft
+
+Title:  <title>
+Suggested: <rewritten title>              ← only if quality gate fired
+Warning:   <what triggered>               ← only if quality gate fired
+Base:   <base-branch>  [stacked ⚠] or [default branch]
+Branch: <current-branch>
+
+Body:
+---
+<body>
+---
+
+Create this PR? yes / edit / cancel
+```
+
+If the title quality gate fired, the `Suggested:` and `Warning:` lines appear. The operator can accept the original, use the suggestion, or type their own via the `edit` flow. If no issues were detected, omit those lines.
+
+Use `AskUserQuestion` to get the response. Options:
+- **yes** → proceed to Phase 5
+- **edit** → the operator pastes corrections; apply them and re-pitch
+- **cancel** → stop, no PR created
+
+## Phase 5 — Create
+
+1. **Push if needed:** if the branch isn't on origin yet, run `git push -u origin <branch>`. Print the push result.
+2. **Create:** use `mcp__github__create_pull_request` with the owner, repo, title, body, base, and head branch.
+3. **Print the PR URL** from the response.
+4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
+
+## Phase 6 — Monitor CI
+
+After the PR is created, launch a **background subagent** to monitor CI status. Do not suggest merging or offer to merge until CI results are in.
+
+The subagent should:
+
+1. **Poll CI checks** using `mcp__github__pull_request_read` periodically or `Bash` with `gh pr checks <pr-number> --watch` until all checks complete or a timeout (10 minutes) is reached.
+2. **On all checks green:**
+   - Report to the user: "CI passed on PR #N. Ready to merge."
+   - Check the repo's merge strategy via `mcp__github__search_repositories` or `mcp__github__get_file_contents`.
+   - Offer to merge using `mcp__github__merge_pull_request`. Wait for explicit approval.
+   - **After merge:** run `git checkout main && git pull --ff-only` (i.e. `git ready`) to return to a clean, up-to-date main. This is the ready position for starting new work. Transition linked tickets to Done.
+3. **On any check red:**
+   - Report the failure: which check failed, link to the logs.
+   - Fetch the failure details via `mcp__github__pull_request_read` and `Bash` with `gh run view <run-id> --log-failed` for actionable output.
+   - Summarize what went wrong and suggest next steps (e.g. "lint failure in X — fixable here" or "test timeout — needs investigation").
+   - Ask the user how to proceed: fix it now (resume pairprog), investigate further, or leave it for later.
+4. **On timeout (no checks appear within 2 minutes):**
+   - Report: "No CI checks have started on PR #N. This repo may not have CI configured for this path, or checks are queued."
+   - Do not suggest merging.
+
+**Key rules:**
+- **Never suggest merging before CI results are known.** A freshly created PR has no check data — don't offer to merge it.
+- The subagent runs in the background so the user can continue other work.
+- If the user explicitly asks to merge before CI completes, warn them that checks haven't finished and confirm they want to proceed.
+
+## Anti-patterns
+
+- **Don't hardcode `main` as base.** Always detect the default branch and check for stacking.
+- **Don't create the PR without pitching.** The operator must see and approve the draft.
+- **Don't fabricate the test plan.** Derive it from the diff or say "verify manually" — don't invent test steps that don't exist.
+- **Don't push without noting it.** If a push is needed, say so before running it.
+- **Don't ask more than one round of questions.** All clarification happens in the pitch → edit loop, not via separate `AskUserQuestion` calls before Phase 4.
+- **Don't suggest merging before CI is green.** A freshly created PR has no check data. Wait for the CI monitor subagent to report results before offering merge options.


### PR DESCRIPTION
## Summary
- 6 engineering skills (commenting, commitmsg, designnote, linearissue, pairprog, pr) now live in KB — they co-evolve with the artifacts they operate on
- designnote and linearissue updated for `docs/decisions/` format: MADR-style serial numbering, new frontmatter schema, unified sections (Context/Exploration/Decision/Consequences/Confirmation)
- Slug generation protocol documented in the designnote skill
- `skills/README.md` covers inventory, dotfiles wiring, and KB/dotfiles split rationale

## Test plan
- [ ] Verify designnote skill has zero references to `docs/design-notes/` (except the slug example)
- [ ] Verify linearissue skill has zero references to `docs/design-notes/`
- [ ] Verify 4 unchanged skills (commenting, commitmsg, pairprog, pr) match dotfiles originals
- [ ] Verify CHANGELOG entry documents the migration

Closes KB-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)