### PR TITLE
KB-27: Docs aligned with unified decisions format and stale references fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **
 
 ---
 
+## [2026-06-10]
+
+### Changed
+- **GUIDELINES.md template** — removed stale `design-notes/` link from "Related Documentation" footer. Updated `decisions/` description to reflect unified format.
+- **PROJECT_SETUP_GUIDE.md** — added AGENTS.md (with CLAUDE.md/GEMINI.md symlinks) to documentation copy commands. Decision record example updated to MADR serial-numbered format. All `cp` paths now use `<path-to-kb>` placeholder instead of hardcoded relative paths.
+
+### Migration
+
+**If your `docs/GUIDELINES.md` references `design-notes/`:**
+
+1. Remove the `design-notes/` line from the "Related Documentation" section at the bottom of the file
+2. Optionally update the `decisions/` description to: `Decision records (exploration through to decided)`
+
 ## [2026-06-05]
 
 ### Added

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -18,9 +18,9 @@ We use a **direnv -> devenv** pattern for environment management. This provides 
 Copy the environment files from the knowledge base into your new project's root.
 
 ```bash
-# Example assumes knowledge-base is cloned next to your project
-cp ../kb/templates/.envrc .envrc
-cp ../kb/templates/.envrc.local.example .envrc.local.example
+# Replace <path-to-kb> with the actual path to your kb checkout
+cp <path-to-kb>/templates/.envrc .envrc
+cp <path-to-kb>/templates/.envrc.local.example .envrc.local.example
 ```
 
 `.envrc` is committed directly — it contains only direnv/devenv boilerplate, no secrets. Secrets go in `.envrc.local` (gitignored).
@@ -83,7 +83,7 @@ Set up automated code quality checks that run before commits:
 **A. Copy Pre-commit Configuration**
 
 ```bash
-cp knowledge-base/.pre-commit-config.yaml .pre-commit-config.yaml
+cp <path-to-kb>/.pre-commit-config.yaml .pre-commit-config.yaml
 ```
 
 **B. Install Pre-commit Hooks**
@@ -164,15 +164,18 @@ Copy the core documentation templates into your project.
 mkdir -p docs
 
 # Copy templates
-cp ../kb/templates/CHANGELOG.md ./
-cp ../kb/templates/CONTRIBUTING.md ./
-cp ../kb/templates/GUIDELINES.md ./docs/
-cp ../kb/templates/TODO.md ./docs/
-cp -r ../kb/templates/decisions ./docs/
+cp <path-to-kb>/templates/CHANGELOG.md ./
+cp <path-to-kb>/templates/CONTRIBUTING.md ./
+cp <path-to-kb>/templates/AGENTS.md ./
+ln -s AGENTS.md CLAUDE.md       # Claude Code reads CLAUDE.md
+ln -s AGENTS.md GEMINI.md       # Gemini reads GEMINI.md
+cp <path-to-kb>/templates/GUIDELINES.md ./docs/
+cp <path-to-kb>/templates/TODO.md ./docs/
+cp -r <path-to-kb>/templates/decisions ./docs/
 ```
 
-> **Note:** `CHANGELOG.md` and `CONTRIBUTING.md` live at the repo root (GitHub convention), not in `docs/`.
-> It owns commit conventions, scope discipline, and merge strategy — see the template for details.
+> **Note:** `CHANGELOG.md`, `CONTRIBUTING.md`, and `AGENTS.md` live at the repo root (GitHub convention / agent discovery), not in `docs/`.
+> `CLAUDE.md` and `GEMINI.md` are symlinks to `AGENTS.md` — edit `AGENTS.md` and the others follow.
 
 Refer to the main [Engineering Handbook (README.md)](./README.md) for the philosophy on when and how to use each of these documents.
 
@@ -219,24 +222,15 @@ Replace template tasks with your project needs:
 - [ ] Configure backup strategy
 ```
 
-### DECISIONS.md First Entry
+### First Decision Record
 
-Document your first major decision in the `docs/decisions` directory, using the template.
+Copy the template and create your first decision record in `docs/decisions/`:
 
-```markdown
-### 2024-01-15 - Framework Selection
-
-**Decision**: Use Next.js with TypeScript for the web application.
-
-**Context**: Need to build a full-stack web application with both static and dynamic content...
-
-**Rationale**:
-
-- Built-in SSR/SSG capabilities
-- Excellent TypeScript support
-- Large ecosystem and community
-- Team familiarity
+```bash
+cp docs/decisions/0000-decision-template.md docs/decisions/0001-framework-selection.md
 ```
+
+Edit the frontmatter and fill in the sections (Context, Exploration, Decision, Consequences, Confirmation). See [templates/decisions/README.md](./templates/decisions/README.md) for the full format reference and status vocabulary.
 
 ## Maintenance & Integration
 

--- a/README.md
+++ b/README.md
@@ -235,29 +235,25 @@ Every project should maintain consistent documentation using our **structured an
 _Ordered by developer workflow relevance_
 
 - **README.md** (`./README.md`) - Project Foundation
+- **CONTRIBUTING.md** (`./CONTRIBUTING.md`) - Commit conventions, scope discipline, merge strategy
 - **GUIDELINES.md** (`./docs/GUIDELINES.md`) - Development Standards and Best Practices
 - **TODO.md** (`./docs/TODO.md`) - Task Management using Now/Next/Later/Never Framework
-- **design-notes/** (`./docs/design-notes/`) - Design Iteration and System Models
-  - **Filename Convention**: `YYYY-MM-DD.STATE.description.md` (e.g. `2025-09-08.WIP.api-design.md`)
-  - **Front Matter**: Each file includes a `title` and a list of `tags` to aid discovery for cross-cutting concerns.
-  - **Status Log**: Table-based tracking of status changes with date, author, tickets, and notes
-  - Used as a scratchpad for evolving ideas. The `STATE` in the filename and Status Log table track lifecycle changes.
-- **decisions/** (`./docs/decisions/`) - Architecture Decision Records (ADR)
-  - **Filename Convention**: `YYYY-MM-DD.STATE.description.md`
-  - **Front Matter**: Includes `title` and `tags`.
-  - Immutable snapshots of final decisions, often graduated from a `DONE` design note.
+- **decisions/** (`./docs/decisions/`) - Decision records (exploration through to decided)
+  - MADR-style serial numbering (`nnnn-slug.md`), enriched frontmatter, status log
+  - See [templates/decisions/README.md](./templates/decisions/README.md) for format details, naming conventions, and status vocabulary
 - **LINTING_FORMATTING.md** (`./docs/LINTING_FORMATTING.md`) - Code Quality Standards _(conditional)_
 - **AGENTS.md** (`./AGENTS.md`) - AI agent guidelines _(conditional)_
+  - `CLAUDE.md` and `GEMINI.md` are symlinks to `AGENTS.md`
 
 ### When to Create Each Document
 
 - **Start with essentials**:
   - **README.md**: Every project foundation.
+  - **CONTRIBUTING.md**: When multiple contributors need aligned commit/merge practices.
   - **GUIDELINES.md**: When README outgrows itself or team needs coding standards.
 - **Add as workflow demands**:
   - **TODO.md**: When you need a repo-specific scratchpad.
-  - **design-notes/**: When exploring complex designs.
-  - **decisions/**: When graduating mature designs from `design-notes/`.
+  - **decisions/**: When exploring designs or recording architectural choices.
   - **LINTING_FORMATTING.md**: Only when team size or complexity demands a separate file.
   - **AI Guidance**: When using AI development tools (`AGENTS.md`).
 
@@ -296,7 +292,7 @@ See [templates/](./templates/) directory for starter templates of each document 
 
 ## Contributing
 
-See [GUIDELINES.md](./templates/GUIDELINES.md) for detailed contribution standards.
+See [CONTRIBUTING.md](./templates/CONTRIBUTING.md) for contribution standards.
 
 ---
 

--- a/templates/GUIDELINES.md
+++ b/templates/GUIDELINES.md
@@ -327,7 +327,6 @@ const { data, isLoading, error } = useQuery({
 
 ## Related Documentation
 
-- [decisions/](./decisions/) - Architectural decisions behind these guidelines
-- [design-notes/](./design-notes/) - System design patterns
+- [decisions/](./decisions/) - Decision records (exploration through to decided)
 - [LINTING_FORMATTING.md](./LINTING_FORMATTING.md) - Code formatting standards
 - [TODO.md](./TODO.md) - Planned guideline improvements


### PR DESCRIPTION
## Summary
- Slimmed README "Documentation Standards" to philosophy-only, linking to template READMEs for format details instead of restating them inline
- Added CONTRIBUTING.md and AGENTS.md to core docs list; fixed Contributing link pointing to GUIDELINES instead of CONTRIBUTING
- Removed stale design-notes/ reference from GUIDELINES.md template footer
- Updated PROJECT_SETUP_GUIDE.md: AGENTS.md + symlink instructions, MADR decision format, `<path-to-kb>` placeholder for all copy commands
- Added CHANGELOG entry with downstream migration instructions

## Test plan
- Verify all internal markdown links resolve correctly
- Check CHANGELOG migration instructions are actionable for a downstream project with a stale GUIDELINES.md

Closes KB-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)