### PR TITLE
feat(skills): enforce cold-reader title validation before ticket creation [KB-32]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,16 @@ This document is the canonical source of truth for commit conventions, scope dis
 - **body** — explain *why*, not *what* (the diff shows what)
 - **footer** — `Co-Authored-By:`, `BREAKING CHANGE:`, references
 
+### AI Co-authorship
+
+Use `Co-authored-by: {Model Name} <noreply@{provider-domain}>` for AI co-authorship. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention for accounts without public emails.
+
+```
+Co-authored-by: Claude Code <noreply@anthropic.com>
+```
+
+This trailer is the canonical AI provenance signal. GitHub renders it as a secondary author avatar on the commit. It survives squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
+
 ### Types
 
 | Type | Use when… |
@@ -44,7 +54,6 @@ This document is the canonical source of truth for commit conventions, scope dis
 | `skills` | Skill definitions in `skills/` |
 | `decisions` | Decision records in `docs/decisions/` |
 | `ci` | CI/CD pipeline configuration |
-| `pr` | The `/pr` skill specifically |
 | `deps` | Dependency updates |
 
 > **Tip:** When no scope fits, omit it: `fix: handle null response from upstream`.
@@ -145,16 +154,16 @@ PR titles follow the same conventional-commit format as individual commits, with
 ```
 
 - **type** and **scope** — same rules as commits (see tables above)
-- **subject** — value-oriented, distinguishing phrase first (see quality gate below)
+- **subject** — imperative mood, value-oriented, distinguishing phrase first. Same imperative voice convention as commits and ticket titles.
 - **`[TICKET-ID]`** — the Linear ticket ID in square brackets, e.g. `[KB-31]`. Auto-injected from the branch name by the `/pr` skill. Omit only for ad-hoc branches without a ticket.
 
 ### Examples
 
 ```
-feat(skills): convention sync for downstream repos [KB-33]
-fix(pr): HITL offers gh CLI commands for repo config [KB-31]
-doc(templates): PR title convention with commit/PR layering [KB-31]
-chore(ci): semantic PR title enforcement [KB-31]
+feat(skills): align repo conventions to KB standards [KB-33]
+fix(skills): offer gh CLI commands for repo config drift [KB-31]
+doc(templates): document PR title convention with commit layering [KB-31]
+chore(ci): enforce semantic PR titles [KB-31]
 ```
 
 ### Why this format?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,20 @@ This document is the canonical source of truth for commit conventions, scope dis
 
 ### AI Co-authorship
 
-Use `Co-authored-by: {Model Name} <noreply@{provider-domain}>` for AI co-authorship. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention for accounts without public emails.
+Use both trailers on every AI-assisted commit during the crossover period:
 
 ```
 Co-authored-by: Claude Code <noreply@anthropic.com>
+Assisted-by: Claude:claude-opus-4-6
 ```
 
-This trailer is the canonical AI provenance signal. GitHub renders it as a secondary author avatar on the commit. It survives squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
+**`Co-authored-by:`** is the established Git/GitHub convention. GitHub renders it as a secondary author avatar. The email (`noreply@anthropic.com`) is a provenance marker, not a contact address.
+
+**`Assisted-by:`** is the emerging standard from the [Linux kernel guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution). Format: `AGENT_NAME:MODEL_VERSION`. No email field — sidesteps the fake-email problem.
+
+Using both ensures GitHub avatar rendering today while building toward the `Assisted-by` standard. Once forges support `Assisted-by` natively, `Co-authored-by` can be dropped.
+
+Both trailers survive squash-merge in the commit body.
 
 ### Types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This document is the canonical source of truth for commit conventions, scope dis
 
 ### AI Co-authorship
 
-Use both trailers on every AI-assisted commit during the crossover period:
+Use both trailers on every AI-assisted commit. `Co-authored-by` works with GitHub today; `Assisted-by` is the emerging standard but forges don't render it yet. Using both ensures nothing is lost as tooling catches up:
 
 ```
 Co-authored-by: Claude Code <noreply@anthropic.com>
@@ -36,7 +36,7 @@ Assisted-by: Claude:claude-opus-4-6
 
 **`Assisted-by:`** is the emerging standard from the [Linux kernel guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution). Format: `AGENT_NAME:MODEL_VERSION`. No email field — sidesteps the fake-email problem.
 
-Using both ensures GitHub avatar rendering today while building toward the `Assisted-by` standard. Once forges support `Assisted-by` natively, `Co-authored-by` can be dropped.
+Once forges render `Assisted-by` natively, `Co-authored-by` can be dropped.
 
 Both trailers survive squash-merge in the commit body.
 

--- a/skills/linearissue/SKILL.md
+++ b/skills/linearissue/SKILL.md
@@ -462,7 +462,13 @@ This structure applies to ticket titles, PR subjects, and commit subjects — th
 ### Principles
 
 1. **Imperative voice with value framing** — every title is a task someone does, phrased as an imperative verb + what it delivers. Choose verbs and nouns that communicate value, not implementation technique. "Enable Google login" not "Implement OAuth callback." The verb should signal the kind of work; the noun should name the value delivered.
-2. **Distinguishing phrase first** — the most identifiable words lead. Linear branch names truncate after ~25 chars past the ticket prefix, so front-loaded meaning survives truncation. When filing related tickets, the differentiator must appear within the first ~25 characters so titles remain distinguishable in truncated views.
+2. **Differentiator survives truncation** — Linear branch names, board columns, and notification previews truncate titles aggressively (~25-30 chars visible). If the distinguishing word sits past the truncation point, related tickets become indistinguishable. The canonical structure `[VERB] [NOUN] [CONTEXT]` naturally solves this — the verb (position 1) and noun (position ~7) are both visible before truncation. When filing related tickets, render the first 30 characters side by side and verify they're distinguishable:
+   ```
+   ✗ "Congressional disclosure da..."  ← identical at 30 chars
+   ✗ "Congressional disclosure da..."
+   ✓ "Trial QuiverQuant for cong..."   ← distinguishable at position 7
+   ✓ "Trial Unusual Whales for c..."
+   ```
 3. **Brevity** — keep titles under 72 characters. Warn above 72. Shorter is almost always better.
 4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
 5. **Branch-name-friendly** — avoid special characters, deep nesting, or parenthetical lists that produce ugly slugs.
@@ -514,7 +520,8 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 - "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Trial bot in Meet/Zoom/WhatsApp calls"
 - "Market data provider comparison for backtesting" → "Survey market data providers"
 - "Worklog cron silent during active flow" → "Silence worklog during active flow"
-- "Congressional disclosure data verified via QuiverQuant trial" → "Trial QuiverQuant for congress disclosures"
+- "Congressional disclosure data verified via QuiverQuant trial" → "Trial QuiverQuant for congress disclosures" ← differentiator ("QuiverQuant") moves from position 47 to position 7; sibling "Trial Unusual Whales..." is instantly distinguishable
+- "Congressional disclosure data verified via Unusual Whales trial" → "Trial Unusual Whales for congress disclosures" ← without this fix, both siblings truncate to identical "Congressional disclosure da..."
 - "QuiverQuant as primary disclosure provider" → "Select disclosure data provider"
 
 ### Titles that pass (no rewrite needed)

--- a/skills/linearissue/SKILL.md
+++ b/skills/linearissue/SKILL.md
@@ -209,16 +209,24 @@ Proposed tickets from: docs/decisions/{filename}
 
  1. [NEW]    {Title}                          Priority: Normal
              Target: {team-key} / {project-name}
+             Cold read: "{one-line interpretation by a zero-context reader}"
+             Truncated: "{title cut at ~30 chars}..."
  2. [NEW]    {Title}                          Priority: High
              Target: {team-key} / {project-name}
+             Cold read: "{interpretation}"
+             Truncated: "{truncated}..."
              ↳ depends on #1
  3. [NEW]    {Title}                          Priority: Normal
              Target: {other-team} / {other-project}  ⚠ routed away from ambient
+             Cold read: "{interpretation}"
+             Truncated: "{truncated}..."
              Suggested: {Rewritten title}  ← title gate fired
              Warning: mechanism verb 'Implement' leading
  4. [UPDATE] {Title} (LIN-123)               Priority: Normal
              Target: {team-key} / {project-name}
              ↳ description changed
+
+⚠ Overlap: #1 and #2 share first 25 chars — differentiator buried past truncation point
 
 Skipped:
  - "already done thing" — marked complete
@@ -226,6 +234,10 @@ Skipped:
 
 {N} new · {K} updates · {S} skipped
 ```
+
+**Cold-reader self-check:** Before presenting the proposal, the skill must simulate a zero-context reader for each title. The "Cold read" line states what the title communicates to someone who has never seen the conversation, ticket, or design note. If the cold read doesn't match the intent, the title fails — rewrite before presenting.
+
+**Batch overlap detection:** When proposing multiple tickets (filing or freeform), compare the first 25 characters of all titles. If any pair shares >50% of those characters, flag it with a `⚠ Overlap` line and suggest reordering so the differentiator leads. Render the truncated titles side-by-side to make the problem visible.
 
 ### Confirm
 
@@ -363,10 +375,16 @@ Proposed issues (freeform)
 
  1. [NEW]  {Title}                          Priority: Normal
            Target: {team-key} / {project-name}
+           Cold read: "{one-line interpretation by a zero-context reader}"
+           Truncated: "{title cut at ~30 chars}..."
            {2-line description preview}
  2. [NEW]  {Title}                          Priority: High
            Target: {other-team} / {other-project}  ⚠ routed away from ambient
+           Cold read: "{interpretation}"
+           Truncated: "{truncated}..."
            {2-line description preview}
+
+⚠ Overlap: #1 and #2 share first 25 chars — differentiator buried past truncation point
 
 {N} new issues
 ```
@@ -375,7 +393,9 @@ If any title triggered the quality gate, show both versions:
 
 ```
  1. [NEW]  {Original title}                 Priority: Normal
-           Suggested: {Rewritten title}  ← value-oriented
+           Cold read: "{interpretation}"
+           Truncated: "{truncated}..."
+           Suggested: {Rewritten title}  ← imperative, value-oriented
            Warning: mechanism verb 'Implement' leading
 ```
 
@@ -418,24 +438,47 @@ Every title — whether derived from a design note action item, drafted in freef
 
 > **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is linearissue-specific) but the core principles and examples should match.
 
+### Canonical structure
+
+All titles follow imperative voice: **`[VERB] [DIFFERENTIATING NOUN] [CONTEXT]`**
+
+The verb signals scope (what kind of work), the noun differentiates (what specifically), the context narrows (where/for whom). Labels carry metadata (Spike, Decision, Bug) — never encode it in the title.
+
+This structure applies to ticket titles, PR subjects, and commit subjects — the same imperative phrasing across all three surfaces. See the verb tiers below for which verbs to use.
+
+### Verb tiers
+
+1. **Preferred — scope-signaling verbs.** These carry real meaning about the kind of work:
+   `Trial` (spike), `Select`/`Choose` (decision), `Survey`/`Map` (research), `Replan`/`Rescope` (replanning), `Ingest`/`Poll` (data pipeline), `Fix`/`Resolve` (bug), `Extract`/`Normalize` (schema work), `Enable` (user-facing capability), `Enforce` (validation/rules), `Drop`/`Remove` (deprecation).
+
+2. **Allowed for task-framing — when no better verb fits.** These convert a feature name into a task when a preferred verb doesn't apply:
+   `Add` (didn't exist before), `Configure` (settings/wiring). Prefer tier 1 when possible.
+
+3. **Banned — generic verbs that describe every ticket.** These add zero information:
+   `Implement`, `Build`, `Create`, `Set up`, `Wire up`, `Compose`, `Inject`, `Conduct`, `Redesign`.
+
+**Drop filler words.** "Survey viable disclosure vendors" → "Survey disclosure vendors". "Viable" does no work — you wouldn't survey non-viable ones.
+
 ### Principles
 
-1. **Value over mechanism** — frame what the issue delivers, not how it's implemented. "Stable room link for live AV" not "Implement re-entrancy for Daily transport". The title should answer "what changes for the user/system?" not "what code do we write?".
-2. **Distinguishing phrase first** — the most identifiable words lead. Linear branch names truncate after ~25 chars past the ticket prefix, so front-loaded meaning survives truncation.
+1. **Imperative voice with value framing** — every title is a task someone does, phrased as an imperative verb + what it delivers. Choose verbs and nouns that communicate value, not implementation technique. "Enable Google login" not "Implement OAuth callback." The verb should signal the kind of work; the noun should name the value delivered.
+2. **Distinguishing phrase first** — the most identifiable words lead. Linear branch names truncate after ~25 chars past the ticket prefix, so front-loaded meaning survives truncation. When filing related tickets, the differentiator must appear within the first ~25 characters so titles remain distinguishable in truncated views.
 3. **Brevity** — keep titles under 72 characters. Warn above 72. Shorter is almost always better.
 4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
 5. **Branch-name-friendly** — avoid special characters, deep nesting, or parenthetical lists that produce ugly slugs.
-6. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Titles are read far more often than they're written, and almost never by the person who wrote them. If the title only makes sense to someone who was in the room, it fails.
+6. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Titles are read far more often than they're written, and almost never by the person who wrote them. If the title only makes sense to someone who was in the room, it fails. Self-check: "Is this a task someone does, or a fact someone reads?" If the latter, reframe as the task that produces that fact.
 
 ### Anti-patterns to detect
 
-- **Mechanism verbs leading** — "Wire up", "Implement", "Add", "Decouple", "Compose", "Inject", "Conduct", "Redesign", "Create", "Build", "Set up" as the first word. Exception: action verbs describing user-facing behavior are fine ("Allow bot to interrupt", "Select auth provider").
+- **Banned verbs (anywhere in the title)** — `Implement`, `Build`, `Create`, `Set up`, `Wire up`, `Compose`, `Inject`, `Conduct`, `Redesign`. These are tier 3 verbs that describe every ticket equally and carry no scope information. See verb tiers above.
+- **Mechanism verbs/phrases (anywhere, not just leading)** — "verified via", "implemented using", "configured with", "wired up through". These describe implementation technique, not value. "Congressional disclosure data verified via QuiverQuant trial" → "Trial QuiverQuant for congress disclosures".
+- **Statement titles** — titles that read as facts or decisions rather than tasks. "QuiverQuant as primary provider" is a statement. "Select disclosure data provider" is a task. Test: could this title appear as a line item on a to-do list? If not, it's a statement, not a task title. Common drift: the agent keeps shifting from task framing into outcome/statement framing.
 - **Bracket tags** — `[Research]`, `[Spike]`, `[WIP]`, `[Bug]` waste leading characters. Use Linear labels.
 - **"Explore/Research/Spike:" prefixes** — metadata that belongs in labels.
 - **Parenthetical lists** — "(Meet, Zoom, WhatsApp)" or "(bioguide_id, thomas_id)" add precision but kill readability. Use slash-separated inline: "Bot joins Meet/Zoom/WhatsApp calls".
 - **Question-format titles** — "Does X expose Y?" belongs in the description.
 - **Kitchen-sink titles** — "Improve X — reduce Y and explore Z" tries to do too much in one title.
-- **Technical-identifier-first** — "bioguide_id mapping for member identity" buries the value. Prefer "Member identity resolver" or "Resolve member identity from bioguide".
+- **Technical-identifier-first** — "bioguide_id mapping for member identity" buries the value. Prefer "Resolve member identity from bioguide".
 - **Redundant context** — "linearissue skill: value-oriented titles + freeform creation mode" — the project/component prefix is redundant when the ticket already has a project and labels.
 - **Context-dependent titles** — titles that only make sense if you were in the conversation that produced them. "Own protocol types at pipecat boundary" means nothing to a cold reader. "Codename alignment across codebase" sounds important but conveys no real value.
 
@@ -462,24 +505,26 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 
 ### Examples (before → after)
 
-- "Implement member identity resolver (bioguide_id mapping)" → "Member identity resolver"
-- "Create ticker identity resolver (security master)" → "Ticker identity from security master"
-- "Add CI job for agents test suite" → "CI for agents test suite"
-- "Set up authentication token storage mechanism" → "Auth token storage"
-- "Wire up Logfire for APM and distributed tracing" → "Logfire APM and tracing"
-- "Explore service-level hooks for production frame-level observability" → "Production frame-level o11y hooks"
-- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Bot joins Meet/Zoom/WhatsApp calls"
-- "Market data provider comparison for backtesting" → "Viable market data providers"
-- "Worklog cron silent during active flow" → "Distraction-free worklog tracking"
+- "Implement member identity resolver (bioguide_id mapping)" → "Resolve member identity from bioguide"
+- "Create ticker identity resolver (security master)" → "Extract ticker identity from security master"
+- "Add CI job for agents test suite" → "Add CI for agents test suite"
+- "Set up authentication token storage mechanism" → "Store auth tokens"
+- "Wire up Logfire for APM and distributed tracing" → "Enable Logfire APM and tracing"
+- "Explore service-level hooks for production frame-level observability" → "Survey production frame-level o11y hooks"
+- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Trial bot in Meet/Zoom/WhatsApp calls"
+- "Market data provider comparison for backtesting" → "Survey market data providers"
+- "Worklog cron silent during active flow" → "Silence worklog during active flow"
+- "Congressional disclosure data verified via QuiverQuant trial" → "Trial QuiverQuant for congress disclosures"
+- "QuiverQuant as primary disclosure provider" → "Select disclosure data provider"
 
 ### Titles that pass (no rewrite needed)
 
-- "Select auth provider" — short, clear, distinguishing
-- "Optimise for showtime" — punchy, value obvious
-- "Allow bot to interrupt" — user-facing behavior, 4 words
-- "Uncensor STT input" — brief, clear what it delivers
-- "Graceful LLM fallback on provider outage" — value-first, concise
-- "Viable market data providers" — outcome-oriented, cold-reader friendly
+- "Select auth provider" — imperative, clear scope (decision), distinguishing
+- "Optimise for showtime" — imperative, punchy, value obvious
+- "Allow bot to interrupt" — imperative, user-facing behavior, 4 words
+- "Uncensor STT input" — imperative, brief, clear what it delivers
+- "Fix duplicate disclosures on concurrent polls" — imperative, bug framing, specific
+- "Trial Unusual Whales for congress disclosures" — imperative, spike framing, differentiator at position 7
 
 ## Anti-patterns
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -156,7 +156,7 @@ Evaluate the drafted title against these criteria. The gate is **advisory** — 
 
 **Principles:**
 1. **Imperative voice with value framing** — the subject is a task phrased as an imperative verb + what it delivers. Choose verbs and nouns that communicate value, not implementation technique. "enable Google login" not "implement OAuth callback." The verb signals the kind of work; the noun names the value delivered.
-2. **Distinguishing phrase first** — the most identifiable words lead, so truncated views stay meaningful.
+2. **Distinguishing phrase first** — the most identifiable words lead. PR titles appear in `git log --oneline` where they're truncated, and in GitHub's PR list where long titles are clipped. The differentiator must appear within the first ~25 characters of the subject so titles remain distinguishable in truncated views. When the same branch of work produces multiple PRs, compare subjects and flag overlap.
 3. **Brevity** — keep the **subject** (the part after `type(scope): ` and before ` [TICKET-ID]`) under 60 characters. Warn above 60. The type/scope prefix and ticket suffix are structural — they don't count against the limit.
 4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
 5. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Self-check: "Is this a task someone does, or a fact someone reads?" If the latter, reframe as the task that produces that fact.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -156,7 +156,13 @@ Evaluate the drafted title against these criteria. The gate is **advisory** — 
 
 **Principles:**
 1. **Imperative voice with value framing** — the subject is a task phrased as an imperative verb + what it delivers. Choose verbs and nouns that communicate value, not implementation technique. "enable Google login" not "implement OAuth callback." The verb signals the kind of work; the noun names the value delivered.
-2. **Distinguishing phrase first** — the most identifiable words lead. PR titles appear in `git log --oneline` where they're truncated, and in GitHub's PR list where long titles are clipped. The differentiator must appear within the first ~25 characters of the subject so titles remain distinguishable in truncated views. When the same branch of work produces multiple PRs, compare subjects and flag overlap.
+2. **Differentiator survives truncation** — `git log --oneline`, GitHub's PR list, and notification previews truncate titles aggressively (~25-30 chars of the subject visible after the `type(scope):` prefix). If the distinguishing word sits past the truncation point, related PRs become indistinguishable. The canonical structure `[VERB] [NOUN] [CONTEXT]` naturally solves this — the verb and noun are both visible before truncation. When the same branch of work produces multiple PRs, render the first 30 characters of each subject side by side and verify they're distinguishable:
+   ```
+   ✗ "congressional disclosure da..."  ← identical at 30 chars
+   ✗ "congressional disclosure da..."
+   ✓ "trial QuiverQuant for cong..."   ← distinguishable at position 7
+   ✓ "trial Unusual Whales for c..."
+   ```
 3. **Brevity** — keep the **subject** (the part after `type(scope): ` and before ` [TICKET-ID]`) under 60 characters. Warn above 60. The type/scope prefix and ticket suffix are structural — they don't count against the limit.
 4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
 5. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Self-check: "Is this a task someone does, or a fact someone reads?" If the latter, reframe as the task that produces that fact.
@@ -201,6 +207,7 @@ Warning:   <what triggered the gate — e.g. "banned verb 'Implement'", "67 char
 - "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "trial bot in Meet/Zoom/WhatsApp calls"
 - "Market data provider comparison for backtesting" → "survey market data providers"
 - "Worklog cron silent during active flow" → "silence worklog during active flow"
+- "congressional disclosure data verified via QuiverQuant trial" → "trial QuiverQuant for congress disclosures" ← differentiator moves from position 47 to position 7; sibling PRs become distinguishable in `git log --oneline`
 
 **Titles that pass (no rewrite needed):**
 - "select auth provider" — imperative, clear scope (decision), distinguishing

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -135,7 +135,7 @@ The branch with the **fewest commits between its tip and HEAD** is the most like
 **Title:**
 1. **Determine the type** from the nature of the change: `feat`, `fix`, `doc`, `refactor`, `chore`, `test`, `style`, or `perf` — same types as commit conventions in CONTRIBUTING.md.
 2. **Determine the scope** (optional) from the primary area of the codebase affected.
-3. **Draft the subject** — use the Linear ticket title as a starting point if available, otherwise derive from the branch name slug (strip the owner prefix and ticket ID, humanize the remainder). The ticket title is a starting point, not a passthrough — always run it through the quality gate (step 6) and rewrite if it doesn't meet PR title standards. *(Note: KB-32 will introduce a ticket title standard. Once that lands, ticket titles should already be closer to PR-ready, but the quality gate still applies.)*
+3. **Draft the subject** — use the Linear ticket title as a starting point if available, otherwise derive from the branch name slug (strip the owner prefix and ticket ID, humanize the remainder). The ticket title is a starting point, not a passthrough — always run it through the quality gate (step 6) and rewrite if it doesn't meet PR title standards. Ticket titles follow the same imperative voice convention (see quality gate below), so they should already be close to PR-ready.
 4. **Append the ticket ID** when one was detected from the branch name in Phase 1. Format: `[KB-10]` in square brackets at the end. This is required for traceability — merged commits produce `type(scope): subject [KB-10] (#N)`, preserving the Linear issue link in `git log`. Omit only for ad-hoc branches without a ticket.
 5. **Assemble the title:** `type(scope): subject [TICKET-ID]`.
 6. Run the title through the **title quality gate** below.
@@ -144,25 +144,33 @@ The branch with the **fewest commits between its tip and HEAD** is the most like
 
 Evaluate the drafted title against these criteria. The gate is **advisory** — warn and suggest, never block.
 
-> **Sync note:** This gate is mirrored in `/linearissue` (`skills/linearissue/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness) but the core principles and examples should match.
+> **Sync note:** This gate is mirrored in `/linearissue` (`skills/linearissue/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold is 60 chars here vs 72 for tickets; no branch-name-friendliness principle here) but the core principles and examples should match.
+
+**Canonical structure:** PR subjects follow the same imperative voice as ticket titles and commit subjects: **`[VERB] [DIFFERENTIATING NOUN] [CONTEXT]`**. The `type(scope):` prefix categorizes the change — it doesn't replace the verb. The subject still needs an imperative verb that carries meaning.
+
+**Verb tiers:**
+
+1. **Preferred — scope-signaling verbs:** `Trial`, `Select`, `Survey`, `Fix`, `Extract`, `Enable`, `Enforce`, `Drop`, `Resolve`, `Ingest`, `Silence`.
+2. **Allowed for task-framing:** `Add`, `Configure` — when no better verb fits.
+3. **Banned — generic verbs:** `Implement`, `Build`, `Create`, `Set up`, `Wire up`, `Compose`, `Inject`, `Conduct`, `Redesign`.
 
 **Principles:**
-1. **Value over mechanism** — frame what the PR delivers, not how it's implemented. "Stable room link for live AV" not "Implement re-entrancy for Daily transport".
-2. **Distinguishing phrase first** — the most identifiable words lead, so truncated branch names (`~25 chars` after the ticket prefix) stay meaningful.
+1. **Imperative voice with value framing** — the subject is a task phrased as an imperative verb + what it delivers. Choose verbs and nouns that communicate value, not implementation technique. "enable Google login" not "implement OAuth callback." The verb signals the kind of work; the noun names the value delivered.
+2. **Distinguishing phrase first** — the most identifiable words lead, so truncated views stay meaningful.
 3. **Brevity** — keep the **subject** (the part after `type(scope): ` and before ` [TICKET-ID]`) under 60 characters. Warn above 60. The type/scope prefix and ticket suffix are structural — they don't count against the limit.
 4. **No metadata in the title** — priority, work type (spike, research), and category belong in labels, not bracket tags or prefixes.
-5. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Titles are read far more often than they're written, and almost never by the person who wrote them. If the title only makes sense to someone who was in the room, it fails.
+5. **Out-of-context readability** — would someone scanning this title weeks later — or a newcomer — understand the value without the conversation that produced it? Self-check: "Is this a task someone does, or a fact someone reads?" If the latter, reframe as the task that produces that fact.
 
 **Anti-patterns to detect:**
-- **Mechanism verbs leading** — "Wire up", "Implement", "Add", "Decouple", "Compose", "Inject", "Conduct", "Redesign" as the first word describe implementation, not value. Exception: action verbs that describe user-facing behavior are fine ("Allow bot to interrupt").
+- **Banned verbs (anywhere in the title)** — `Implement`, `Build`, `Create`, `Set up`, `Wire up`, `Compose`, `Inject`, `Conduct`, `Redesign`. Tier 3 verbs that carry no scope information.
+- **Mechanism verbs/phrases (anywhere, not just leading)** — "verified via", "implemented using", "configured with", "wired up through". These describe implementation technique, not value.
+- **Statement titles** — titles that read as facts rather than tasks. "OAuth callback for Google login" is a statement; "enable Google login" is a task. Test: could this appear on a to-do list?
 - **Bracket tags** — `[Research]`, `[Spike]`, `[WIP]` waste leading characters. Use labels instead.
-- **"Explore/Research/Spike:" prefixes** — front-load metadata that belongs in labels.
-- **"Draft design note:" prefixes** — the work type is obvious from context.
-- **"Fix broken..." with mechanism** — "Fix broken X — replace Y with Z" buries the value. Prefer "X works again" or name the symptom.
-- **Parenthetical lists** — "(Meet, Zoom, WhatsApp)" or "(Cartesia disconnect, room leave)" add precision but kill branch readability.
+- **"Explore/Research/Spike:" prefixes** — metadata that belongs in labels.
+- **Parenthetical lists** — "(Meet, Zoom, WhatsApp)" add precision but kill readability. Use slash-separated inline.
 - **Question-format titles** — "Does X expose Y?" belongs in the description.
 - **Kitchen-sink titles** — "Improve X — reduce Y and explore Z" tries to do too much in one title.
-- **Context-dependent titles** — titles that only make sense if you were in the conversation that produced them. "Own protocol types at pipecat boundary" means nothing to a cold reader. "Codename alignment across codebase" sounds important but conveys no real value.
+- **Context-dependent titles** — titles that only make sense if you were in the conversation that produced them.
 
 **Out-of-context failures (from audit):**
 
@@ -181,26 +189,24 @@ If any issues are detected, draft a suggested rewrite alongside the original. Pr
 
 ```
 Title:     <original title>
-Suggested: <rewritten title>  ← value-oriented, distinguishing phrase first
-Warning:   <what triggered the gate — e.g. "mechanism verb 'Implement' leading", "67 chars (>60)">
+Suggested: <rewritten title>  ← imperative, value-oriented
+Warning:   <what triggered the gate — e.g. "banned verb 'Implement'", "67 chars (>60)">
 ```
 
 **Examples (before → after):**
-- "Wire up Logfire for APM and distributed tracing" → "Logfire APM and tracing"
-- "Implement e2e tests: HTTP contract and Daily room verification" → "E2e tests for /connect and Daily"
-- "Explore service-level hooks for production frame-level observability" → "Production frame-level o11y hooks"
-- "Decouple FilterSink frame-type routing from pipecat string class names" → "Decouple frame routing from pipecat"
-- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "Bot joins Meet/Zoom/WhatsApp calls"
-- "Graceful LLM provider fallback when primary flakes" → "LLM fallback on provider outage"
-- "Market data provider comparison for backtesting" → "Viable market data providers"
-- "Worklog cron silent during active flow" → "Distraction-free worklog tracking"
+- "Wire up Logfire for APM and distributed tracing" → "enable Logfire APM and tracing"
+- "Implement e2e tests: HTTP contract and Daily room verification" → "add e2e tests for /connect and Daily"
+- "Explore service-level hooks for production frame-level observability" → "survey production frame-level o11y hooks"
+- "Decouple FilterSink frame-type routing from pipecat string class names" → "decouple frame routing from pipecat"
+- "Architectural spike: bot-as-participant in external video calls (Meet, Zoom, WhatsApp)" → "trial bot in Meet/Zoom/WhatsApp calls"
+- "Market data provider comparison for backtesting" → "survey market data providers"
+- "Worklog cron silent during active flow" → "silence worklog during active flow"
 
 **Titles that pass (no rewrite needed):**
-- "Select auth provider" — short, clear, distinguishing
-- "Optimise for showtime" — punchy, value obvious
-- "Allow bot to interrupt" — user-facing behavior, 4 words
-- "Uncensor STT input" — brief, clear what it delivers
-- "Viable market data providers" — outcome-oriented, cold-reader friendly
+- "select auth provider" — imperative, clear scope (decision), distinguishing
+- "allow bot to interrupt" — imperative, user-facing behavior, 4 words
+- "fix duplicate disclosures on concurrent polls" — imperative, bug framing, specific
+- "enforce semantic PR titles" — imperative, clear what it delivers
 
 **Body:**
 ```markdown

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This document is the canonical source of truth for commit conventions, scope dis
 
 ### AI Co-authorship
 
-Use both trailers on every AI-assisted commit during the crossover period:
+Use both trailers on every AI-assisted commit. `Co-authored-by` works with GitHub today; `Assisted-by` is the emerging standard but forges don't render it yet. Using both ensures nothing is lost as tooling catches up:
 
 ```
 Co-authored-by: Claude Code <noreply@anthropic.com>
@@ -36,7 +36,7 @@ Assisted-by: Claude:claude-opus-4-6
 
 **`Assisted-by:`** is the emerging standard from the [Linux kernel guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution). Format: `AGENT_NAME:MODEL_VERSION`. No email field — sidesteps the fake-email problem. Not yet widely supported by forges, but forward-compatible.
 
-Using both ensures GitHub avatar rendering today while building toward the `Assisted-by` standard. Once forges support `Assisted-by` natively, `Co-authored-by` can be dropped.
+Once forges render `Assisted-by` natively, `Co-authored-by` can be dropped.
 
 Both trailers survive squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
 

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -23,6 +23,19 @@ This document is the canonical source of truth for commit conventions, scope dis
 - **body** — explain *why*, not *what* (the diff shows what)
 - **footer** — `Co-Authored-By:`, `BREAKING CHANGE:`, references
 
+### AI Co-authorship
+
+Use `Co-authored-by: {Model Name} <noreply@{provider-domain}>` for AI co-authorship. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention for accounts without public emails.
+
+```
+Co-authored-by: Claude Code <noreply@anthropic.com>
+Co-authored-by: ChatGPT <noreply@openai.com>
+Co-authored-by: Gemini <noreply@google.com>
+Co-authored-by: Copilot <noreply@github.com>
+```
+
+This trailer is the canonical AI provenance signal. GitHub renders it as a secondary author avatar on the commit. It survives squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
+
 ### Types
 
 | Type | Use when… |
@@ -150,16 +163,16 @@ PR titles follow the same conventional-commit format as individual commits, with
 ```
 
 - **type** and **scope** — same rules as commits (see tables above)
-- **subject** — value-oriented, distinguishing phrase first (see quality gate below)
+- **subject** — imperative mood, value-oriented, distinguishing phrase first. Same imperative voice convention as commits and ticket titles.
 - **`[TICKET-ID]`** — the Linear ticket ID in square brackets, e.g. `[KB-31]`. Auto-injected from the branch name by the `/pr` skill. Omit only for ad-hoc branches without a ticket.
 
 ### Examples
 
 ```
-feat(auth): OAuth callback for Google login [KB-31]
-fix: null response from upstream handled [KB-45]
-doc: contributing guide updated with PR title convention [KB-31]
-chore(ci): semantic PR title enforcement [KB-31]
+feat(auth): enable Google login [KB-31]
+fix: handle null response from upstream [KB-45]
+doc: update contributing guide with PR title convention [KB-31]
+chore(ci): enforce semantic PR titles [KB-31]
 ```
 
 ### Why this format?

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -25,16 +25,20 @@ This document is the canonical source of truth for commit conventions, scope dis
 
 ### AI Co-authorship
 
-Use `Co-authored-by: {Model Name} <noreply@{provider-domain}>` for AI co-authorship. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention for accounts without public emails.
+Use both trailers on every AI-assisted commit during the crossover period:
 
 ```
 Co-authored-by: Claude Code <noreply@anthropic.com>
-Co-authored-by: ChatGPT <noreply@openai.com>
-Co-authored-by: Gemini <noreply@google.com>
-Co-authored-by: Copilot <noreply@github.com>
+Assisted-by: Claude:claude-opus-4-6
 ```
 
-This trailer is the canonical AI provenance signal. GitHub renders it as a secondary author avatar on the commit. It survives squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
+**`Co-authored-by:`** is the established Git/GitHub convention. GitHub renders it as a secondary author avatar on the commit. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention. Use `noreply@{provider-domain}` (e.g. `noreply@anthropic.com`, `noreply@openai.com`, `noreply@google.com`).
+
+**`Assisted-by:`** is the emerging standard from the [Linux kernel guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution). Format: `AGENT_NAME:MODEL_VERSION`. No email field — sidesteps the fake-email problem. Not yet widely supported by forges, but forward-compatible.
+
+Using both ensures GitHub avatar rendering today while building toward the `Assisted-by` standard. Once forges support `Assisted-by` natively, `Co-authored-by` can be dropped.
+
+Both trailers survive squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
 
 ### Types
 


### PR DESCRIPTION
## Summary

* Unified imperative voice model (`[VERB] [NOUN] [CONTEXT]`) across ticket titles, PR subjects, and commit subjects — same phrasing, different wrapping
* 3-tier verb system (preferred scope-signaling / allowed task-framing / banned generic) with concrete examples per task type
* Cold-reader self-check and truncation rendering added to linearissue confirmation output
* Batch overlap detection flags sibling titles with shared prefixes before creation
* New anti-patterns: statement titles (fact vs task), mechanism verbs anywhere (not just leading)
* Co-authored-by trailer convention codified in CONTRIBUTING.md template and local copy
* Dropped `[ai:agent]` from PR title format — trailer carries provenance

## Test plan

- [X] Review linearissue quality gate (canonical copy) for completeness
- [X] Verify pr skill quality gate mirrors core principles and examples
- [X] Check CONTRIBUTING.md AI Co-authorship section and PR title examples
- [x] Confirm redundant `pr` scope removed from local CONTRIBUTING.md

Closes [KB-32](https://linear.app/asabina/issue/KB-32/ticket-titles-validated-for-cold-reader-clarity-before-creation)<br>[KB-32](https://linear.app/asabina/issue/KB-32/ticket-titles-validated-for-cold-reader-clarity-before-creation)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)