### PR TITLE
doc: add missed KB-32 changelog and pre-PR completeness checklist [KB-32]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Execute these commands (detailed explanations in README.md):
 - Example: `feat: add user auth [ai:claude]`
 - Break work into focused, single-concern commits
 - Stick to short commit titles that are less than 80 characters long
-- Add a "Co-authored by:" line in suggested commit messages
+- Add `Co-authored-by:` and `Assisted-by:` trailers in commit messages (see CONTRIBUTING.md for format)
 
 ### Pre-Commit Workflow
 
@@ -150,6 +150,13 @@ Execute these commands (detailed explanations in README.md):
 4. **Stage your changes**: `git add .`
 5. **Commit with proper message format**
 6. **Verify commit was signed**: `git log --show-signature -1`
+
+### Pre-PR Checklist
+
+Before opening a pull request, verify:
+
+1. **CHANGELOG.md** — if the branch changes templates, skills, or conventions that downstream repos consume, add a dated entry to `CHANGELOG.md` with what changed and migration steps. The CHANGELOG is how downstream repos discover what to sync. Forgetting it means the change is invisible to other projects.
+2. **CONTRIBUTING.md** — if commit or PR conventions changed, verify the local `CONTRIBUTING.md` reflects the new rules.
 
 ## Communication
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Assisted-by: Claude:claude-opus-4-6
 
 No action needed — the skill no longer adds this tag. Provenance is in the commit trailers.
 
+**Audit existing tickets against the new title standard:**
+
+The imperative voice model applies to future tickets automatically (the `/linearissue` quality gate enforces it), but existing tickets in Backlog, Todo, and In Progress were written under the old standard. These are worth auditing because non-compliant titles often signal deeper problems: vague scope, missing DoD, or work that should be split.
+
+Run through open tickets and check for:
+- **Statement titles** (fact, not task) — "QuiverQuant as primary provider" → "Select disclosure data provider"
+- **Buried differentiators** — siblings that truncate identically on a board
+- **Banned verbs** — "Implement X", "Build Y", "Create Z" → replace with scope-signaling verbs
+- **Mechanism framing** — titles that describe implementation, not value
+- **Scope gaps** — tickets that are too broad or lack a concrete DoD
+
+This is a one-time cleanup per project. KB-33 will provide a `/kbsync` skill to automate this audit across repos.
+
 ## [2026-06-11]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **
 
 ---
 
+## [2026-06-12]
+
+### Changed
+- **`/linearissue` and `/pr` skill quality gates** — unified imperative voice model: `[VERB] [DIFFERENTIATING NOUN] [CONTEXT]` as canonical title structure across tickets, PRs, and commits. Added 3-tier verb system (preferred scope-signaling / allowed task-framing / banned generic), statement-title anti-pattern, mechanism verb detection anywhere (not just leading position), and "Differentiator survives truncation" principle with inline truncation rendering.
+- **`/linearissue` confirmation output** — now includes a cold-reader interpretation line and truncated-at-30 rendering per ticket, plus batch overlap detection flagging sibling titles with shared prefixes.
+- **AI Co-authorship convention** in `templates/CONTRIBUTING.md` — dual-trailer convention: `Co-authored-by` (GitHub avatar rendering today) + `Assisted-by` (Linux kernel emerging standard, forward-compatible). Documents `noreply@{provider-domain}` email convention and `AGENT_NAME:MODEL_VERSION` format.
+- **`/pr` skill** — dropped `[ai:agent]` tag from PR title format. Provenance is carried by `Co-authored-by` and `Assisted-by` trailers in the commit body, which survive squash-merge.
+
+### Migration
+
+**If your project's CONTRIBUTING.md has an AI Co-authorship section:**
+
+Update to include both trailers:
+```
+Co-authored-by: Claude Code <noreply@anthropic.com>
+Assisted-by: Claude:claude-opus-4-6
+```
+
+**If your `/pr` skill generates titles with `[ai:agent]` suffix:**
+
+No action needed — the skill no longer adds this tag. Provenance is in the commit trailers.
+
 ## [2026-06-11]
 
 ### Added

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -138,6 +138,13 @@ See CONTRIBUTING.md for the full workflow. Quick reference:
 6. **Commit with proper message format**
 7. **Verify commit was signed**: `git log --show-signature -1`
 
+### Pre-PR Checklist
+
+Before opening a pull request, verify:
+
+1. **CHANGELOG.md** — if the branch changes templates, conventions, or anything downstream repos consume, add a dated entry to `CHANGELOG.md` with what changed and migration steps. The CHANGELOG is how downstream repos discover what to sync. Forgetting it means the change is invisible to other projects.
+2. **CONTRIBUTING.md** — if commit or PR conventions changed, verify `CONTRIBUTING.md` reflects the new rules.
+
 ## AI Provenance
 
 All AI contributions must be clearly identifiable:


### PR DESCRIPTION
## Summary
- Add missing CHANGELOG entry for KB-32 changes (imperative voice model, dual-trailer convention, cold-reader checks)
- Add Pre-PR Checklist to AGENTS.md (local + template) requiring CHANGELOG and CONTRIBUTING.md verification before opening PRs
- Update commit strategy to reference both Co-authored-by and Assisted-by trailers

## Test plan
- [ ] Verify CHANGELOG [2026-06-12] entry covers KB-32 scope
- [ ] Verify Pre-PR Checklist is in both AGENTS.md and templates/AGENTS.md
- [ ] Verify commit strategy references dual trailers

Closes KB-32
https://linear.app/asabina/issue/KB-32/ticket-titles-validated-for-cold-reader-clarity-before-creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)