### PR TITLE
feat(skills): draft align skill for convention alignment [KB-33]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,36 @@
 # Changelog
 
-All notable changes to the KB templates are documented in this file.
+All notable changes to the KB conventions are documented in this file.
 
 This project ships continuously — there are no versioned releases. Each entry is dated when it merges to main. Downstream repos can scan by date to discover what changed since they last synced.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **Migration** section for template changes that require action in downstream repos.
+Format follows [Keep a Changelog](https://keepachangelog.com/), with an added **Migration** section for changes that require action in downstream repos.
 
 **Migration instructions are stateless.** If you see the described artifacts in your project, the migration applies to you — no need to know which "version" you're on.
+
+### Writing migration entries
+
+A convention change affects **resources** — anything that must be updated to achieve parity. Resources are not limited to files in the repo. They include anything the changed code or convention *expects to exist and behave a certain way*.
+
+When writing a migration entry, infer the affected resources from the change itself: what does this change assume about the world? Those assumptions are your resource list. Group migration steps by resource type so readers can route each step to the right person or tool.
+
+Common resource types (not exhaustive — infer from context):
+
+- **Files** — templates, configs, workflows, skill definitions, documentation
+- **Repo settings** — merge mode, branch protection, squash title format (GitHub Settings)
+- **Tickets** — existing backlog titles, descriptions, DoDs, scope, breakdown
+- **CI/CD** — pipeline configs, check requirements, environment variables
+- **Infrastructure** — service configs, secrets, env vars, deployment settings
+- **Database** — schema migrations, seed data, connection strings
+- **Observability** — dashboards, alerts, log schemas, metric definitions
+- **External services** — API keys, webhook registrations, platform configs
+
+Tag manual-only steps with **(manual)** so readers know an agent can't automate them:
+
+```markdown
+**Repo settings (manual):**
+- Set squash-merge title source to "Pull request title" in GitHub Settings > Pull Requests
+```
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the KB conventions are documented in this file.
+All notable changes to the KB (knowledge base) conventions are documented in this file.
 
 This project ships continuously — there are no versioned releases. Each entry is dated when it merges to main. Downstream repos can scan by date to discover what changed since they last synced.
 

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: align
+description: "Use this skill when the user wants to bring a repo's conventions into alignment with the KB standards. Trigger for prompts like 'align this repo', 'sync conventions', 'check what's out of date', 'run the migration', 'what KB changes apply here', or when the user invokes `/align`. The skill reads the KB's CHANGELOG.md for stateless migration instructions, assesses the current repo's state across all resource types (files, repo settings, tickets, CI/CD, infra), and presents a gap analysis. Migrations are applied interactively with operator approval. Do NOT trigger for creating new conventions (that's a design task), for KB development itself (the KB repo is the source, not a target), or for one-off file edits that don't relate to convention alignment."
+allowed-tools: Bash Glob Grep Read Edit Write Agent AskUserQuestion Skill mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__list_issue_labels mcp__github__search_repositories mcp__github__get_file_contents mcp__github__list_branches
+---
+
+# align
+
+Bring a repo's conventions into alignment with the KB standards. **Assess everything, fix nothing without approval.**
+
+The defining design principles:
+
+> **The CHANGELOG is the source of truth.** The KB's `CHANGELOG.md` carries dated, stateless migration instructions. The skill reads them, assesses which apply to the current repo, and presents the gaps. It does not hardcode conventions — it follows whatever the CHANGELOG says.
+>
+> **Resources, not just files.** Convention changes affect multiple resource types: files, repo settings, tickets, CI/CD, infrastructure, databases, observability, external services. The skill infers affected resources from what each convention change assumes about the world, and checks all of them.
+>
+> **Critical by default.** The skill pushes back when migration scope is incomplete — if a CHANGELOG entry implies a resource type that the repo hasn't addressed, the skill flags it rather than silently skipping. It also flags destructive operations and requires explicit confirmation before proceeding.
+>
+> **Safe and reversible.** Destructive operations (file deletions, renames, config changes that affect all contributors) are flagged with warnings and require explicit confirmation. The skill prefers additive changes (create new files, append sections) over destructive ones (delete, overwrite). When a migration step can't be undone, say so before executing.
+>
+> **Interactive, not autonomous.** Every migration step is presented, explained, and approved before execution. The operator can skip, defer, or modify any step. Batch approval is available for mechanical steps, but destructive or ambiguous steps are always individual.
+
+## How this skill relates to other skills
+
+```
+KB repo (source of truth)
+  │
+  ├── CHANGELOG.md — dated migration entries with resource-typed steps
+  ├── templates/ — canonical file templates
+  └── skills/ — skill definitions (including this one)
+        │
+        ▼
+/align (this skill) — reads CHANGELOG, assesses target repo, presents gaps
+  │
+  ├── File migrations → Edit/Write directly
+  ├── Repo settings → surface gh CLI commands (HITL)
+  ├── Ticket migrations → /linearissue for title/scope fixes
+  └── Manual steps → surface instructions, can't automate
+```
+
+## Phase 0 — Locate the KB
+
+The skill needs access to the KB repo's `CHANGELOG.md`. Discover it in this order:
+
+1. **Symlink at repo root:** check for `./kb` or `./knowledge-base` symlink. If present, use it.
+2. **Explicit path:** if the user passed a path argument (e.g. `/align ~/Code/asabina-de/kb`), use it.
+3. **Environment variable:** check `$KB_PATH` if set.
+4. **Ask:** if none of the above, ask the operator: "Where is the KB repo? Provide a path, or set up a `./kb` symlink."
+
+Verify the path by checking for `CHANGELOG.md` at the root. If missing, refuse: "No CHANGELOG.md found at {path} — this doesn't look like the KB repo."
+
+Read the full `CHANGELOG.md`. Parse each dated section, extracting:
+- **Date** — when the change landed
+- **Changed/Added/Removed items** — what changed
+- **Migration steps** — grouped by resource type (or ungrouped in older entries)
+
+## Phase 1 — Assess the target repo
+
+Read the target repo's current state in parallel:
+
+- **Repo docs:** `CONTRIBUTING.md`, `AGENTS.md` / `CLAUDE.md`, `README.md`, `CHANGELOG.md`
+- **CI/CD:** `.github/workflows/`, `.pre-commit-config.yaml`
+- **Repo config:** `.github-settings.yaml`, `.gitignore`, `.envrc`
+- **Templates vs local:** compare local files against KB `templates/` to detect drift
+- **Git config:** merge strategy, branch protection (via `gh api` if available)
+- **Recent history:** `git log --oneline -20` for convention compliance in recent commits
+
+### Infer resource scope
+
+For each CHANGELOG migration entry, infer what resource types it affects:
+
+1. Read the migration steps — they may already be grouped by resource type (newer entries).
+2. For ungrouped entries (older format), infer: does this change affect files? Repo settings? Tickets? CI? Read the "Changed" description to understand what the convention assumes.
+3. Build a resource map: `{changelog_date: [{resource_type, migration_step, applies: bool, status: done|gap|partial|unknown}]}`
+
+### Detect gaps
+
+For each migration step, check whether the target repo has already applied it:
+
+**Files:**
+- Does the file exist? Does its content match the expected pattern?
+- Use `Grep` for pattern matching (e.g. "does CONTRIBUTING.md have an 'AI Co-authorship' section?")
+- Compare against the KB template version for drift
+
+**Repo settings:**
+- Read `.github-settings.yaml` if present — compare declared settings against the KB template
+- If no `.github-settings.yaml`, flag as "repo settings not declared — unknown compliance"
+- Check observable settings via `gh api repos/{owner}/{repo}` if `gh` is available
+
+**Tickets:**
+- Fetch open issues from Linear (`list_issues` filtered by project/team)
+- Run each title through the quality gate: imperative voice, verb tiers, statement detection, truncation check
+- Check descriptions for DoD presence
+- Flag scope issues: overly broad tickets, missing breakdown
+
+**CI/CD:**
+- Check for expected workflows (e.g. `lint-pr.yaml`)
+- Compare workflow content against KB template version
+
+## Phase 2 — Present the gap analysis
+
+Print a structured report:
+
+```
+Convention alignment report for {repo-name}
+KB reference: {kb-path}/CHANGELOG.md
+Last KB entry: [YYYY-MM-DD]
+
+✅ Up to date (N items)
+  - [2026-06-05] decisions/ consolidation — applied
+  - [2026-06-04] CONTRIBUTING.md template — applied
+
+⚠️  Gaps found (M items)
+
+  [2026-06-12] Imperative voice title standard
+    Files:     ✅ CONTRIBUTING.md has PR title convention
+    Tickets:   ⚠️  5 of 12 open tickets have statement titles
+    Repo settings: ✅ .github-settings.yaml present
+
+  [2026-06-11] Semantic PR title CI enforcement
+    Files:     ❌ No .github/workflows/lint-pr.yaml
+    Repo settings: ❌ No .github-settings.yaml
+    Files:     ⚠️  CONTRIBUTING.md missing PR Title Convention section
+
+❓ Cannot assess (K items)
+  - [2026-06-11] Squash-merge title format — no gh CLI access to check GitHub settings
+
+📋 Migration plan: {total} steps across {resource_types} resource types
+   {N} automated · {M} manual · {K} destructive (require confirmation)
+```
+
+### Push back on incomplete scope
+
+After presenting gaps, check whether the migration entries themselves cover all resource types implied by the change. If a CHANGELOG entry changes a convention but its migration steps only cover files (not tickets, not repo settings), flag it:
+
+```
+⚠️  Migration scope may be incomplete:
+
+  [2026-06-12] Imperative voice title standard
+    The CHANGELOG migration steps cover files but not tickets.
+    This convention change also affects existing ticket titles in the backlog.
+    Recommend: audit open tickets for statement titles before proceeding.
+```
+
+The skill should propose additional migration steps for uncovered resource types and add them to the plan with operator approval.
+
+### Flag destructive operations
+
+Before presenting the migration plan, classify each step:
+
+- **Additive** — creates new files, appends sections. Safe, reversible.
+- **Modifying** — edits existing content. Reversible via git.
+- **Destructive** — deletes files, renames, changes repo-wide settings. Harder to reverse.
+- **External** — changes outside the repo (GitHub settings, Linear tickets, CI config). May affect all contributors.
+
+Mark destructive and external steps clearly:
+
+```
+Step 3: ⚠️ DESTRUCTIVE — Remove design-notes/ directory
+  git rm -r docs/design-notes/
+  This cannot be undone without git history recovery.
+  
+Step 5: 🔧 EXTERNAL — Set squash-merge title to "PR title" (manual)
+  gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_title=PR_TITLE
+  This affects all contributors immediately.
+```
+
+## Phase 3 — Execute migrations
+
+Present the full migration plan as a numbered checklist:
+
+```
+Migration plan ({N} steps)
+
+ 1. [auto]    Copy .github/workflows/lint-pr.yaml from KB template
+ 2. [auto]    Add PR Title Convention section to CONTRIBUTING.md
+ 3. [auto]    Add AI Co-authorship section to CONTRIBUTING.md
+ 4. [manual]  Set squash-merge title format in GitHub Settings
+              gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_title=PR_TITLE
+ 5. [auto]    Create .github-settings.yaml from KB template
+ 6. [tickets] Audit 5 ticket titles for imperative voice compliance
+ 7. ⚠️ [destructive] Remove docs/design-notes/ (migrated to docs/decisions/)
+
+Execute all auto steps? (manual/destructive steps are always individual)
+```
+
+Use `AskUserQuestion` with options:
+- **Execute all auto steps** — run all non-destructive automated steps, then present manual/destructive ones individually
+- **Step through one by one** — present each step for individual approval
+- **Skip to specific step** — jump to a numbered step
+- **Bail** — stop, no changes made
+
+### Executing steps
+
+For each approved step:
+
+1. **Announce** what's about to happen and which resource type it affects.
+2. **Execute** the change:
+   - **File changes:** `Edit` / `Write` / `Bash` (for `git mv`, `git rm`)
+   - **Repo settings:** surface `gh` CLI commands for the operator. On explicit approval ("go ahead"), execute them. Never auto-execute external changes.
+   - **Ticket changes:** delegate to the `/linearissue` skill for title rewrites and scope fixes. Present proposed changes and get approval before applying.
+   - **Manual steps:** print instructions clearly. Mark as done only when the operator confirms they've completed it.
+3. **Verify** the step succeeded — re-run the gap check for that specific item.
+4. **Mark complete** and move to the next step.
+
+### Defensive measures
+
+- **Before any file edit:** verify the file exists and show what will change. Never blindly overwrite.
+- **Before any deletion:** show what will be deleted and confirm. Suggest `git rm` over `rm` for tracked files so the change is in the commit history.
+- **Before any rename:** check for references to the old name in other files and flag them.
+- **Before any repo setting change:** warn that this affects all contributors and confirm.
+- **Before any ticket change:** show the current title/description alongside the proposed change.
+- **On failure:** stop the current step, report what happened, and ask how to proceed. Don't continue to the next step — the operator may want to fix manually.
+
+## Phase 4 — Summary
+
+Print what was accomplished:
+
+```
+Alignment complete for {repo-name}
+
+Applied:
+ ✅ Step 1: Copied lint-pr.yaml workflow
+ ✅ Step 2: Added PR Title Convention to CONTRIBUTING.md
+ ✅ Step 3: Added AI Co-authorship to CONTRIBUTING.md
+ ✅ Step 5: Created .github-settings.yaml
+
+Manual (operator to complete):
+ 📋 Step 4: Set squash-merge title format — gh command provided above
+
+Skipped:
+ ⏭️ Step 7: design-notes/ removal — operator deferred
+
+Tickets audited:
+ ✅ 3 titles rewritten to imperative voice
+ ⏭️ 2 titles kept as-is (operator approved current wording)
+
+Files changed: {list}
+Suggested commit: doc: align repo conventions to KB standards [YYYY-MM-DD] [ai:claude]
+```
+
+Do not commit — git is HITL. Present the suggested commit message using `commitmsg` methodology.
+
+## Anti-patterns
+
+- **Don't hardcode conventions.** Read them from the KB CHANGELOG. If the CHANGELOG doesn't mention it, the skill doesn't enforce it.
+- **Don't silently skip resource types.** If a convention change implies tickets should be audited but the CHANGELOG entry only covers files, flag the gap — don't ignore it.
+- **Don't auto-execute destructive operations.** File deletions, renames, repo setting changes, and ticket modifications always require individual confirmation.
+- **Don't auto-execute external changes.** Repo settings, CI config, and anything outside the local repo are HITL — surface commands, don't run them unless explicitly approved.
+- **Don't apply migrations out of order.** Some migrations depend on earlier ones (e.g. "add CONTRIBUTING.md" must happen before "add PR Title Convention section to CONTRIBUTING.md"). Respect the dependency chain.
+- **Don't modify the KB repo itself.** This skill targets downstream repos. The KB repo is the source of truth — use normal development workflow to change it.
+- **Don't fabricate migration steps.** If the CHANGELOG doesn't specify a step, don't invent one. Flag the gap and ask the operator whether to add it.
+- **Don't mark manual steps as done.** Only the operator can confirm manual steps are complete. Don't assume.
+- **Don't batch destructive steps.** Even if the operator chose "execute all auto steps", destructive steps are always presented individually.
+- **Don't ignore older CHANGELOG entries.** A repo that hasn't synced in months may need to apply multiple rounds of migrations. Walk through all applicable entries, oldest first.
+
+## Future direction: ticket-per-alignment-run
+
+A planned enhancement: before executing migrations (Phase 3), the skill should file a tracking ticket via `/linearissue` — e.g. "Align conventions to KB 2026-06-12 state" — scoped to the gaps found in Phase 2. Each Phase 3 step would post a progress comment threaded on that ticket via `/commenting`, and the Phase 4 summary would become the resolution comment. This gives alignment runs an audit trail: what was checked, what was applied, what was skipped, and why — visible to auditors and future contributors without reading CLI session logs.

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -165,6 +165,14 @@ Step 5: 🔧 EXTERNAL — Set squash-merge title to "PR title" (manual)
   This affects all contributors immediately.
 ```
 
+### File tracking ticket
+
+Before executing any migrations, file a tracking ticket via `/linearissue` scoped to the gaps found in Phase 2. Title format: `Align conventions to KB YYYY-MM-DD state` (or more specific if only a subset of entries apply). The ticket description should list the migration steps as a checklist.
+
+If the operator prefers not to file a ticket (e.g. the alignment is trivial), skip — but offer it. For non-trivial runs (3+ steps, destructive operations, ticket audits), strongly recommend it.
+
+Store the ticket ID — all Phase 3 progress comments thread on it via `/commenting`.
+
 ## Phase 3 — Execute migrations
 
 Present the full migration plan as a numbered checklist:
@@ -201,7 +209,8 @@ For each approved step:
    - **Ticket changes:** delegate to the `/linearissue` skill for title rewrites and scope fixes. Present proposed changes and get approval before applying.
    - **Manual steps:** print instructions clearly. Mark as done only when the operator confirms they've completed it.
 3. **Verify** the step succeeded — re-run the gap check for that specific item.
-4. **Mark complete** and move to the next step.
+4. **Comment progress** — if a tracking ticket was filed, post a progress comment via `/commenting` threaded on it. Include what was done, what resource type it affected, and any decisions made (e.g. "operator chose to keep original title for KB-14"). This builds the audit trail.
+5. **Mark complete** and move to the next step.
 
 ### Defensive measures
 
@@ -241,6 +250,12 @@ Suggested commit: doc: align repo conventions to KB standards [YYYY-MM-DD] [ai:c
 
 Do not commit — git is HITL. Present the suggested commit message using `commitmsg` methodology.
 
+### Close the tracking ticket
+
+If a tracking ticket was filed in Phase 2, post a resolution comment via `/commenting` with the full summary above (applied, manual, skipped, tickets audited). This is the audit record — anyone reviewing the alignment run later sees exactly what was checked, what was changed, and what decisions the operator made.
+
+Transition the ticket to Done if all steps are complete (including manual ones confirmed by the operator). If manual steps remain, leave it In Progress with the outstanding items listed in the comment.
+
 ## Anti-patterns
 
 - **Don't hardcode conventions.** Read them from the KB CHANGELOG. If the CHANGELOG doesn't mention it, the skill doesn't enforce it.
@@ -254,6 +269,3 @@ Do not commit — git is HITL. Present the suggested commit message using `commi
 - **Don't batch destructive steps.** Even if the operator chose "execute all auto steps", destructive steps are always presented individually.
 - **Don't ignore older CHANGELOG entries.** A repo that hasn't synced in months may need to apply multiple rounds of migrations. Walk through all applicable entries, oldest first.
 
-## Future direction: ticket-per-alignment-run
-
-A planned enhancement: before executing migrations (Phase 3), the skill should file a tracking ticket via `/linearissue` — e.g. "Align conventions to KB 2026-06-12 state" — scoped to the gaps found in Phase 2. Each Phase 3 step would post a progress comment threaded on that ticket via `/commenting`, and the Phase 4 summary would become the resolution comment. This gives alignment runs an audit trail: what was checked, what was applied, what was skipped, and why — visible to auditors and future contributors without reading CLI session logs.

--- a/skills/linearissue/SKILL.md
+++ b/skills/linearissue/SKILL.md
@@ -107,10 +107,22 @@ When filing a batch, run the check per ticket — different items may route to d
 If the triage surfaces a match, present options via `AskUserQuestion`:
 - **Fold into VID-XYZ** — add scope to the existing ticket (comment the new context)
 - **Stack on VID-XYZ** — create as a sub-issue or related issue
+- **Mark as duplicate** — set `duplicateOf` on the old ticket, transition to Cancelled, and **comment why** on the cancelled ticket (see cancellation rule below)
 - **Create new** — confirmed isolated, proceed with filing
 - **Cancel** — the user decides to handle it differently
 
 Only proceed to filing after the user confirms the triage result.
+
+### Cancellation and duplication rule
+
+**Every ticket state change that removes a ticket from the active backlog (Cancelled, Duplicate) must carry a comment explaining why.** A cancelled ticket with no explanation is a dead end for anyone reviewing the backlog later — they can't tell if it was superseded, descoped, invalid, or accidentally closed.
+
+When cancelling or duplicating a ticket:
+1. Post a comment via `/commenting` with a heading like "Cancelled: {reason}" or "Duplicated by {TICKET-ID}"
+2. Include a one-sentence explanation of why (e.g. "KB-36 bundles this rename with two others — same mechanical pattern, one ticket instead of three")
+3. If superseded by another ticket, reference it so readers can follow the chain
+
+This rule applies regardless of which skill triggers the cancellation — `/linearissue` triage, `/pairprog` scope discovery, or manual operator action. If the operator cancels directly, suggest the comment.
 
 ### Filing mode: parse invocation
 
@@ -552,6 +564,7 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 - **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
 - **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
+- **Don't cancel or duplicate tickets without commenting why.** Every state change that removes a ticket from the active backlog must carry a comment explaining the reason. A cancelled ticket with no explanation is a dead end for backlog reviewers. See the cancellation rule in Phase 0.
 
 ## Required grants
 

--- a/skills/pairprog/SKILL.md
+++ b/skills/pairprog/SKILL.md
@@ -31,8 +31,10 @@ The defining design principles are:
 
 The skill supports two commit modes. The navigator can switch between them at any time during the session. A typical pattern on non-trivial work: start in checkpoint to refine the design through implementation, then switch to yolo once the remaining work is known and trivial.
 
-- **Checkpoint mode:** The skill presents each atomic change and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
-- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation. The navigator can interrupt at any time to steer.
+- **Checkpoint mode:** The skill presents each atomic change with a drafted commit message (using the `commitmsg` skill's methodology) and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
+- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill's methodology for message generation. The navigator can interrupt at any time to steer.
+
+**Commit messages are always drafted via `commitmsg` methodology** — reading `CONTRIBUTING.md` for the repo's convention and applying it. The modes differ in who *commits* (yolo: auto, checkpoint: navigator), not who *drafts the message*. Never draft commit messages freehand.
 
 **Milestone file commit gate.** A `PostToolUse` hook monitors edits to milestone files (package manifests, lock files, flake.nix, etc.). When you see a `CHECKPOINT:` message from this hook, you **MUST** immediately:
 1. Stop implementation work
@@ -297,9 +299,10 @@ For each step:
 4. **Decision record maintenance.** If the step touches a file in `docs/decisions/`, append a Status Log row: today's date, `claude` as author, the ticket ID in Related Tickets, and a concise note (e.g. "Updated via pairprog KB-9"). This keeps the record's audit trail intact.
 5. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
 6. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
-7. **Checkpoint.**
-   - **Checkpoint mode:** Pause for the navigator's steering input. This is about design direction — does this approach hold up? Should we change course? If the navigator says "looks good," they commit. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
-   - **Yolo mode:** Invoke the `commitmsg` skill's methodology (read repo convention, draft message) and auto-commit. Print the commit hash and message. Continue to the next step.
+7. **Draft commit message.** In both modes, use the `commitmsg` skill's methodology to draft the message: read `CONTRIBUTING.md` for the repo's convention (type, scope, subject rules, imperative mood, length limits), inspect the diff, and produce a conforming message. Never draft commit messages freehand — the convention is in the docs, not in your training data.
+8. **Checkpoint.**
+   - **Checkpoint mode:** Present the change summary and the drafted commit message. Pause for the navigator's steering input. If the navigator says "looks good," they commit using the drafted message. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
+   - **Yolo mode:** Auto-commit with the drafted message. Print the commit hash and message. Continue to the next step.
 
    **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.
 

--- a/templates/CHANGELOG.md
+++ b/templates/CHANGELOG.md
@@ -18,7 +18,27 @@ Scan from the top. Find the date after your last sync. Everything above that dat
 1. Add a new `## [YYYY-MM-DD]` heading at the top (below this intro)
 2. Categorize changes under `### Added`, `### Changed`, `### Removed`, `### Fixed`, or `### Deprecated`
 3. If any change requires action from consumers, add a `### Migration` section with stateless instructions
-4. Keep entries concise — link to tickets or design notes for full context
+4. **Enumerate all affected resources** — not just files. See "Affected resources" below.
+5. Keep entries concise — link to tickets or design notes for full context
+
+### Affected resources
+
+A convention change affects **resources** — anything that must be updated to achieve parity. Resources are not limited to files in the repo. They include anything the changed code or convention *expects to exist and behave a certain way*.
+
+When writing a migration entry, infer the affected resources from the change: what does this change assume about the world? Those assumptions are your resource list. Group migration steps by resource type so readers can route each step to the right person or tool.
+
+Common resource types (not exhaustive — infer from context):
+
+- **Files** — templates, configs, workflows, skill definitions, documentation
+- **Repo settings** — merge mode, branch protection, squash title format
+- **Tickets** — existing backlog titles, descriptions, DoDs, scope, breakdown
+- **CI/CD** — pipeline configs, check requirements, environment variables
+- **Infrastructure** — service configs, secrets, env vars, deployment settings
+- **Database** — schema migrations, seed data, connection strings
+- **Observability** — dashboards, alerts, log schemas, metric definitions
+- **External services** — API keys, webhook registrations, platform configs
+
+Tag manual-only steps with **(manual)** so readers know an agent can't automate them.
 
 <!-- Template entry — copy and fill in:
 
@@ -35,10 +55,13 @@ Scan from the top. Find the date after your last sync. Everything above that dat
 
 ### Migration
 
-**If you have [artifact/pattern] in your project:**
+**Files:**
+- Step one
 
-1. Step one
-2. Step two
-3. Step three
+**Repo settings (manual):**
+- Step two
+
+**Tickets:**
+- Audit open backlog for [pattern] and fix
 
 -->


### PR DESCRIPTION
## Summary
- Draft `/align` skill: reads KB CHANGELOG for stateless migration instructions, assesses target repo across all resource types (files, repo settings, tickets, CI/CD, infra), presents gap analysis with resource-type grouping, pushes back on incomplete migration scope, and executes migrations interactively with defensive measures for destructive operations
- Add resource-aware migration guidance to CHANGELOG.md (local + template): conventions affect resources beyond files, migration entries must enumerate all affected resource types
- Fix pairprog to delegate commit message drafting to commitmsg methodology in both checkpoint and yolo modes — prevents convention bypass on freehand message drafting
- 9 KB backlog ticket titles renamed to imperative voice (applied via Linear API as dog-food test)

## Test plan
- [ ] Review `/align` SKILL.md for completeness and flow
- [ ] Verify CHANGELOG preamble covers resource-aware migration guidance
- [ ] Verify pairprog skill references commitmsg in both modes
- [ ] Check KB backlog titles are now imperative voice in Linear

Closes KB-33
https://linear.app/asabina/issue/KB-33/draft-align-skill-for-convention-alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)