### PR TITLE
feat(ci): Linear skill deployment workflows [KB-37]

### DIFF
--- a/.github/scripts/linear-skills.mjs
+++ b/.github/scripts/linear-skills.mjs
@@ -1,0 +1,326 @@
+// Sync skills/*/SKILL.md to Linear agent skills.
+//
+// Usage: node linear-skills.mjs <check|deploy>
+//
+//   check  — dry run for PRs. Diffs repo (base + head) against Linear and
+//            prints a per-team plan (CREATE / UPDATE / DELETE / DRIFT /
+//            CONFLICT / UP-TO-DATE). Read-only; never mutates Linear.
+//   deploy — upserts every repo skill to each team and deletes orphans
+//            (skills on Linear with no matching repo dir). Exits non-zero
+//            if any mutation fails.
+//
+// Env:
+//   LINEAR_API_KEY     — personal/OAuth API key (required)
+//   LINEAR_SKILL_TEAMS — comma-separated team names, e.g. "vidbina,zero"
+//   GITHUB_BASE_SHA    — PR base commit (check mode only; for drift detection)
+//
+// A skill's Linear title is its directory name under skills/.
+// When either env var is missing the script is a graceful noop (fork-friendly).
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LinearClient } from "@linear/sdk";
+
+const SKILLS_DIR = "skills";
+
+const mode = process.argv[2];
+if (mode !== "check" && mode !== "deploy") {
+  console.error(`Usage: node linear-skills.mjs <check|deploy>`);
+  process.exit(2);
+}
+
+const apiKey = process.env.LINEAR_API_KEY;
+const teamsRaw = process.env.LINEAR_SKILL_TEAMS;
+
+if (!apiKey || !teamsRaw) {
+  console.log(
+    "Skipping skill sync — LINEAR_API_KEY or LINEAR_SKILL_TEAMS not configured.",
+  );
+  process.exit(0);
+}
+
+const linear = new LinearClient({ apiKey });
+const gql = (query, variables) => linear.client.rawRequest(query, variables);
+
+// --- Linear API ---
+
+async function resolveTeamId(name) {
+  const { data } = await gql(
+    `query($name: String!) { teams(filter: { name: { eq: $name } }) { nodes { id } } }`,
+    { name },
+  );
+  return data?.teams?.nodes?.[0]?.id ?? "";
+}
+
+async function fetchTeamSkills(teamId) {
+  const { data } = await gql(
+    `query($teamId: ID!) {
+       agentSkills(filter: { team: { id: { eq: $teamId } }, shared: { eq: true } }) {
+         nodes { id title body }
+       }
+     }`,
+    { teamId },
+  );
+  return data?.agentSkills?.nodes ?? [];
+}
+
+async function createSkill(title, body, teamId) {
+  const { data } = await gql(
+    `mutation($input: AgentSkillCreateInput!) {
+       agentSkillCreate(input: $input) { success }
+     }`,
+    { input: { title, body, teamId } },
+  );
+  return data?.agentSkillCreate?.success === true;
+}
+
+async function updateSkill(id, title, body) {
+  const { data } = await gql(
+    `mutation($id: String!, $input: AgentSkillUpdateInput!) {
+       agentSkillUpdate(id: $id, input: $input) { success }
+     }`,
+    { id, input: { title, body } },
+  );
+  return data?.agentSkillUpdate?.success === true;
+}
+
+async function deleteSkill(id) {
+  const { data } = await gql(
+    `mutation($id: String!) { agentSkillDelete(id: $id) { success } }`,
+    { id },
+  );
+  return data?.agentSkillDelete?.success === true;
+}
+
+// --- repo helpers ---
+
+function discoverRepoSkills() {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => {
+      try {
+        readFileSync(join(SKILLS_DIR, name, "SKILL.md"));
+        return true;
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function skillBodyOnDisk(skill) {
+  try {
+    return readFileSync(join(SKILLS_DIR, skill, "SKILL.md"), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function skillBodyAtRef(ref, skill) {
+  try {
+    return execFileSync(
+      "git",
+      ["show", `${ref}:${SKILLS_DIR}/${skill}/SKILL.md`],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+  } catch {
+    return "";
+  }
+}
+
+function unifiedDiff(a, b) {
+  const dir = mkdtempSync(join(tmpdir(), "skilldiff-"));
+  const fa = join(dir, "a");
+  const fb = join(dir, "b");
+  writeFileSync(fa, a);
+  writeFileSync(fb, b);
+  try {
+    execFileSync("diff", [fa, fb], { encoding: "utf8" });
+    return ""; // identical
+  } catch (err) {
+    return err.stdout ?? ""; // diff exits 1 when files differ
+  }
+}
+
+const teamNames = teamsRaw
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+const repoSkills = discoverRepoSkills();
+
+if (mode === "check") {
+  await runCheck();
+} else {
+  await runDeploy();
+}
+
+// --- check (PR dry run) ---
+
+async function runCheck() {
+  const baseSha = process.env.GITHUB_BASE_SHA ?? "";
+
+  console.log("## Linear Skill Deployment Plan\n");
+  console.log(`Skills in repo: ${repoSkills.join(", ")}\n`);
+
+  let anyChanges = false;
+
+  for (const teamName of teamNames) {
+    const teamId = await resolveTeamId(teamName);
+    if (!teamId) {
+      console.log(`### Team: ${teamName} (NOT FOUND — skipping)\n`);
+      continue;
+    }
+
+    console.log(`### Team: ${teamName}\n`);
+    const linearSkills = await fetchTeamSkills(teamId);
+    const byTitle = new Map(linearSkills.map((s) => [s.title, s]));
+
+    for (const skill of repoSkills) {
+      const baseBody = baseSha ? skillBodyAtRef(baseSha, skill) : "";
+      const headBody = skillBodyOnDisk(skill);
+      const existing = byTitle.get(skill);
+      const linearBody = existing?.body ?? "";
+      const linearId = existing?.id ?? "";
+
+      if (!headBody) {
+        if (linearId) {
+          console.log(
+            `- **${skill}**: DELETE (file removed, exists on Linear)`,
+          );
+          anyChanges = true;
+        }
+      } else if (!linearId) {
+        console.log(`- **${skill}**: CREATE`);
+        anyChanges = true;
+      } else if (headBody === linearBody) {
+        console.log(`- **${skill}**: UP-TO-DATE`);
+      } else if (baseBody !== headBody && baseBody === linearBody) {
+        console.log(`- **${skill}**: UPDATE (changed in this PR)`);
+        anyChanges = true;
+      } else if (baseBody === headBody && headBody !== linearBody) {
+        console.log(
+          `- **${skill}**: DRIFT (Linear edited manually, no file change)`,
+        );
+        printDiff("Drift diff (repo vs Linear)", headBody, linearBody);
+        anyChanges = true;
+      } else if (baseBody !== headBody && baseBody !== linearBody) {
+        console.log(`- **${skill}**: CONFLICT (file and Linear both changed)`);
+        printDiff("File diff (base to head)", baseBody, headBody);
+        printDiff("Linear drift (base to Linear)", baseBody, linearBody);
+        anyChanges = true;
+      } else {
+        console.log(`- **${skill}**: UPDATE (content differs)`);
+        anyChanges = true;
+      }
+    }
+
+    const orphans = linearSkills.filter((s) => !repoSkills.includes(s.title));
+    if (orphans.length) {
+      console.log(`\n**Orphaned skills on Linear** (not in repo):`);
+      for (const o of orphans) console.log(`- ${o.title}`);
+    }
+
+    console.log("");
+  }
+
+  if (!anyChanges) console.log("No skill changes detected.");
+}
+
+function printDiff(summary, a, b) {
+  const d = unifiedDiff(a, b);
+  console.log("");
+  console.log(`  <details><summary>${summary}</summary>\n`);
+  console.log("  ```diff");
+  console.log(d.replace(/\n$/, ""));
+  console.log("  ```");
+  console.log("  </details>\n");
+}
+
+// --- deploy (post-merge) ---
+
+async function runDeploy() {
+  console.log(`Skills in repo: ${repoSkills.join(", ")}\n`);
+
+  let created = 0;
+  let updated = 0;
+  let deleted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const teamName of teamNames) {
+    const teamId = await resolveTeamId(teamName);
+    if (!teamId) {
+      console.log(`=== Team: ${teamName} (NOT FOUND — skipping) ===\n`);
+      continue;
+    }
+
+    console.log(`=== Team: ${teamName} ===`);
+    const linearSkills = await fetchTeamSkills(teamId);
+    const byTitle = new Map(linearSkills.map((s) => [s.title, s]));
+
+    for (const skill of repoSkills) {
+      const fileBody = skillBodyOnDisk(skill);
+      const existing = byTitle.get(skill);
+
+      try {
+        if (!existing) {
+          console.log(`  CREATE: ${skill}`);
+          (await createSkill(skill, fileBody, teamId)) ? created++ : fail();
+        } else if (fileBody !== existing.body) {
+          console.log(`  UPDATE: ${skill}`);
+          (await updateSkill(existing.id, skill, fileBody))
+            ? updated++
+            : fail();
+        } else {
+          console.log(`  UP-TO-DATE: ${skill}`);
+          skipped++;
+        }
+      } catch (err) {
+        console.log(`  FAILED: ${err.message ?? err}`);
+        failed++;
+      }
+
+      function fail() {
+        console.log(`  FAILED: ${skill}`);
+        failed++;
+      }
+    }
+
+    const orphans = linearSkills.filter((s) => !repoSkills.includes(s.title));
+    for (const orphan of orphans) {
+      console.log(`  DELETE (orphan): ${orphan.title}`);
+      try {
+        if (await deleteSkill(orphan.id)) {
+          deleted++;
+        } else {
+          console.log(`  FAILED: ${orphan.title}`);
+          failed++;
+        }
+      } catch (err) {
+        console.log(`  FAILED: ${err.message ?? err}`);
+        failed++;
+      }
+    }
+
+    console.log("");
+  }
+
+  console.log("=== Summary ===");
+  console.log(`Created: ${created}`);
+  console.log(`Updated: ${updated}`);
+  console.log(`Deleted: ${deleted}`);
+  console.log(`Skipped: ${skipped}`);
+  console.log(`Failed:  ${failed}`);
+
+  if (failed > 0) {
+    console.log(`::error::${failed} skill deployments failed`);
+    process.exit(1);
+  }
+}

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "linear-skills-ci",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "linear-skills-ci",
+      "version": "0.0.0",
+      "dependencies": {
+        "@linear/sdk": "^86.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@linear/sdk": {
+      "version": "86.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-86.0.0.tgz",
+      "integrity": "sha512-Lr47874CGGPCDiPQoKYjcZDWyyu18N8zzEGvss86uzjZaeZrhNsuwKTARswG27VAJ3fPVJAvl/5dPl8QwndSlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "linear-skills-ci",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CI-only tooling: sync skills/*/SKILL.md to Linear agent skills.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "check": "node linear-skills.mjs check",
+    "deploy": "node linear-skills.mjs deploy"
+  },
+  "dependencies": {
+    "@linear/sdk": "^86.0.0"
+  }
+}

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -2,6 +2,8 @@ name: Linear skill check
 
 on:
   pull_request:
+    # opened: PR first created. synchronize: new commits pushed to PR branch.
+    # Together = "run on creation and every subsequent push."
     types: [opened, synchronize]
     # TODO: uncomment paths filter once verified — KB-37
     # paths:

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -6,6 +6,8 @@ on:
     # TODO: uncomment paths filter once verified — KB-37
     # paths:
     #   - 'skills/**'
+    #   - '.github/scripts/**'
+    #   - '.github/workflows/linear-skill-check.yaml'
 
 permissions:
   pull-requests: read
@@ -20,165 +22,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/scripts/package-lock.json
+
+      - name: Install deps
+        working-directory: .github/scripts
+        run: npm ci
+
+      # Run from the repo root so the script sees skills/ at cwd. Node resolves
+      # @linear/sdk from .github/scripts/node_modules via the script's own path.
       - name: Plan skill deployment
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_SKILL_TEAMS: ${{ vars.LINEAR_SKILL_TEAMS }}
-        run: |
-          set -euo pipefail
-
-          SKILLS_DIR="skills"
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-
-          # --- noop guard ---
-
-          if [ -z "${LINEAR_API_KEY:-}" ] || [ -z "${LINEAR_SKILL_TEAMS:-}" ]; then
-            echo "Skipping skill deployment check — LINEAR_API_KEY or LINEAR_SKILL_TEAMS not configured."
-            exit 0
-          fi
-
-          # --- helpers ---
-
-          gql() {
-            local response
-            response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$1")
-            local http_code
-            http_code=$(echo "$response" | tail -1)
-            local body
-            body=$(echo "$response" | sed '$d')
-            if [ "$http_code" -ge 400 ]; then
-              echo "GraphQL error (HTTP $http_code): $body" >&2
-              return 1
-            fi
-            echo "$body"
-          }
-
-          fetch_team_skills() {
-            local team_id="$1"
-            local q="{ agentSkills(filter: { team: { id: { eq: \"${team_id}\" } }, shared: { eq: true } }) { nodes { id title body } } }"
-            local payload
-            payload=$(jq -nc --arg q "$q" '{query: $q}')
-            gql "$payload" | jq -r '.data.agentSkills.nodes // []'
-          }
-
-          resolve_team_id() {
-            local team_name="$1"
-            local q="{ teams(filter: { name: { eq: \"${team_name}\" } }) { nodes { id name } } }"
-            local payload
-            payload=$(jq -nc --arg q "$q" '{query: $q}')
-            gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
-          }
-
-          skill_body_at() {
-            local ref="$1" skill="$2"
-            git show "$ref:$SKILLS_DIR/$skill/SKILL.md" 2>/dev/null || echo ""
-          }
-
-          # --- discover skills from repo ---
-
-          repo_skills=()
-          for dir in "$SKILLS_DIR"/*/; do
-            skill=$(basename "$dir")
-            if [ -f "$dir/SKILL.md" ]; then
-              repo_skills+=("$skill")
-            fi
-          done
-
-          echo "## Linear Skill Deployment Plan"
-          echo ""
-          echo "Skills in repo: ${repo_skills[*]}"
-          echo ""
-
-          # --- iterate teams ---
-
-          IFS=',' read -ra TEAM_NAMES <<< "$LINEAR_SKILL_TEAMS"
-          any_changes=false
-
-          for team_name in "${TEAM_NAMES[@]}"; do
-            team_name=$(echo "$team_name" | xargs)  # trim whitespace
-            team_id=$(resolve_team_id "$team_name")
-
-            if [ -z "$team_id" ]; then
-              echo "### Team: $team_name (NOT FOUND — skipping)"
-              echo ""
-              continue
-            fi
-
-            echo "### Team: $team_name"
-            echo ""
-
-            linear_skills=$(fetch_team_skills "$team_id")
-
-            for skill in "${repo_skills[@]}"; do
-              base_body=$(skill_body_at "$BASE_SHA" "$skill")
-              head_body=$(skill_body_at "HEAD" "$skill")
-
-              linear_body=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .body // ""')
-              linear_id=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .id // ""')
-
-              if [ -z "$head_body" ]; then
-                if [ -n "$linear_id" ]; then
-                  echo "- **$skill**: DELETE (file removed, exists on Linear)"
-                  any_changes=true
-                fi
-              elif [ -z "$linear_id" ]; then
-                echo "- **$skill**: CREATE"
-                any_changes=true
-              elif [ "$head_body" = "$linear_body" ]; then
-                echo "- **$skill**: UP-TO-DATE"
-              elif [ "$base_body" != "$head_body" ] && [ "$base_body" = "$linear_body" ]; then
-                echo "- **$skill**: UPDATE (changed in this PR)"
-                any_changes=true
-              elif [ "$base_body" = "$head_body" ] && [ "$head_body" != "$linear_body" ]; then
-                echo "- **$skill**: DRIFT (Linear edited manually, no file change)"
-                echo ""
-                echo "  <details><summary>Drift diff (repo vs Linear)</summary>"
-                echo ""
-                echo '  ```diff'
-                diff <(echo "$head_body") <(echo "$linear_body") || true
-                echo '  ```'
-                echo "  </details>"
-                echo ""
-              elif [ "$base_body" != "$head_body" ] && [ "$base_body" != "$linear_body" ]; then
-                echo "- **$skill**: CONFLICT (file and Linear both changed)"
-                echo ""
-                echo "  <details><summary>File diff (base to head)</summary>"
-                echo ""
-                echo '  ```diff'
-                diff <(echo "$base_body") <(echo "$head_body") || true
-                echo '  ```'
-                echo "  </details>"
-                echo ""
-                echo "  <details><summary>Linear drift (base to Linear)</summary>"
-                echo ""
-                echo '  ```diff'
-                diff <(echo "$base_body") <(echo "$linear_body") || true
-                echo '  ```'
-                echo "  </details>"
-                echo ""
-                any_changes=true
-              else
-                echo "- **$skill**: UPDATE (content differs)"
-                any_changes=true
-              fi
-            done
-
-            # Check for skills on Linear not in repo (orphans)
-            orphans=$(echo "$linear_skills" | jq -r --argjson repo "$(printf '%s\n' "${repo_skills[@]}" | jq -R . | jq -s .)" '[.[] | select(.title as $t | $repo | index($t) | not)] | .[].title')
-            if [ -n "$orphans" ]; then
-              echo ""
-              echo "**Orphaned skills on Linear** (not in repo):"
-              while IFS= read -r orphan; do
-                echo "- $orphan"
-              done <<< "$orphans"
-            fi
-
-            echo ""
-          done
-
-          if [ "$any_changes" = false ]; then
-            echo "No skill changes detected."
-          fi
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node .github/scripts/linear-skills.mjs check

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -3,8 +3,9 @@ name: Linear skill check
 on:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - 'skills/**'
+    # TODO: uncomment paths filter once verified — KB-37
+    # paths:
+    #   - 'skills/**'
 
 permissions:
   pull-requests: read

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -40,23 +40,35 @@ jobs:
           # --- helpers ---
 
           gql() {
-            curl -sf -X POST https://api.linear.app/graphql \
+            local response
+            response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer $LINEAR_API_KEY" \
-              -d "$1"
+              -d "$1")
+            local http_code
+            http_code=$(echo "$response" | tail -1)
+            local body
+            body=$(echo "$response" | sed '$d')
+            if [ "$http_code" -ge 400 ]; then
+              echo "GraphQL error (HTTP $http_code): $body" >&2
+              return 1
+            fi
+            echo "$body"
           }
 
           fetch_team_skills() {
             local team_id="$1"
+            local q="{ agentSkills(filter: { team: { id: { eq: \"${team_id}\" } }, shared: { eq: true } }) { nodes { id title body } } }"
             local payload
-            payload=$(jq -nc --arg tid "$team_id" '{query: "{ agentSkills(filter: { team: { id: { eq: \"\($tid)\" } }, shared: { eq: true } }) { nodes { id title body } } }"}')
+            payload=$(jq -nc --arg q "$q" '{query: $q}')
             gql "$payload" | jq -r '.data.agentSkills.nodes // []'
           }
 
           resolve_team_id() {
             local team_name="$1"
+            local q="{ teams(filter: { name: { eq: \"${team_name}\" } }) { nodes { id name } } }"
             local payload
-            payload=$(jq -nc --arg name "$team_name" '{query: "{ teams(filter: { name: { eq: \"\($name)\" } }) { nodes { id name } } }"}')
+            payload=$(jq -nc --arg q "$q" '{query: $q}')
             gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
           }
 

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -43,7 +43,7 @@ jobs:
             local response
             response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
               -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $LINEAR_API_KEY" \
+              -H "Authorization: $LINEAR_API_KEY" \
               -d "$1")
             local http_code
             http_code=$(echo "$response" | tail -1)

--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -1,0 +1,171 @@
+name: Linear skill check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'skills/**'
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check-skills:
+    name: Check Linear skill deployment plan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Plan skill deployment
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_SKILL_TEAMS: ${{ vars.LINEAR_SKILL_TEAMS }}
+        run: |
+          set -euo pipefail
+
+          SKILLS_DIR="skills"
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+
+          # --- noop guard ---
+
+          if [ -z "${LINEAR_API_KEY:-}" ] || [ -z "${LINEAR_SKILL_TEAMS:-}" ]; then
+            echo "Skipping skill deployment check — LINEAR_API_KEY or LINEAR_SKILL_TEAMS not configured."
+            exit 0
+          fi
+
+          # --- helpers ---
+
+          gql() {
+            curl -sf -X POST https://api.linear.app/graphql \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $LINEAR_API_KEY" \
+              -d "$1"
+          }
+
+          fetch_team_skills() {
+            local team_id="$1"
+            local payload
+            payload=$(jq -nc --arg tid "$team_id" '{query: "{ agentSkills(filter: { team: { id: { eq: \"\($tid)\" } }, shared: { eq: true } }) { nodes { id title body } } }"}')
+            gql "$payload" | jq -r '.data.agentSkills.nodes // []'
+          }
+
+          resolve_team_id() {
+            local team_name="$1"
+            local payload
+            payload=$(jq -nc --arg name "$team_name" '{query: "{ teams(filter: { name: { eq: \"\($name)\" } }) { nodes { id name } } }"}')
+            gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
+          }
+
+          skill_body_at() {
+            local ref="$1" skill="$2"
+            git show "$ref:$SKILLS_DIR/$skill/SKILL.md" 2>/dev/null || echo ""
+          }
+
+          # --- discover skills from repo ---
+
+          repo_skills=()
+          for dir in "$SKILLS_DIR"/*/; do
+            skill=$(basename "$dir")
+            if [ -f "$dir/SKILL.md" ]; then
+              repo_skills+=("$skill")
+            fi
+          done
+
+          echo "## Linear Skill Deployment Plan"
+          echo ""
+          echo "Skills in repo: ${repo_skills[*]}"
+          echo ""
+
+          # --- iterate teams ---
+
+          IFS=',' read -ra TEAM_NAMES <<< "$LINEAR_SKILL_TEAMS"
+          any_changes=false
+
+          for team_name in "${TEAM_NAMES[@]}"; do
+            team_name=$(echo "$team_name" | xargs)  # trim whitespace
+            team_id=$(resolve_team_id "$team_name")
+
+            if [ -z "$team_id" ]; then
+              echo "### Team: $team_name (NOT FOUND — skipping)"
+              echo ""
+              continue
+            fi
+
+            echo "### Team: $team_name"
+            echo ""
+
+            linear_skills=$(fetch_team_skills "$team_id")
+
+            for skill in "${repo_skills[@]}"; do
+              base_body=$(skill_body_at "$BASE_SHA" "$skill")
+              head_body=$(skill_body_at "HEAD" "$skill")
+
+              linear_body=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .body // ""')
+              linear_id=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .id // ""')
+
+              if [ -z "$head_body" ]; then
+                if [ -n "$linear_id" ]; then
+                  echo "- **$skill**: DELETE (file removed, exists on Linear)"
+                  any_changes=true
+                fi
+              elif [ -z "$linear_id" ]; then
+                echo "- **$skill**: CREATE"
+                any_changes=true
+              elif [ "$head_body" = "$linear_body" ]; then
+                echo "- **$skill**: UP-TO-DATE"
+              elif [ "$base_body" != "$head_body" ] && [ "$base_body" = "$linear_body" ]; then
+                echo "- **$skill**: UPDATE (changed in this PR)"
+                any_changes=true
+              elif [ "$base_body" = "$head_body" ] && [ "$head_body" != "$linear_body" ]; then
+                echo "- **$skill**: DRIFT (Linear edited manually, no file change)"
+                echo ""
+                echo "  <details><summary>Drift diff (repo vs Linear)</summary>"
+                echo ""
+                echo '  ```diff'
+                diff <(echo "$head_body") <(echo "$linear_body") || true
+                echo '  ```'
+                echo "  </details>"
+                echo ""
+              elif [ "$base_body" != "$head_body" ] && [ "$base_body" != "$linear_body" ]; then
+                echo "- **$skill**: CONFLICT (file and Linear both changed)"
+                echo ""
+                echo "  <details><summary>File diff (base to head)</summary>"
+                echo ""
+                echo '  ```diff'
+                diff <(echo "$base_body") <(echo "$head_body") || true
+                echo '  ```'
+                echo "  </details>"
+                echo ""
+                echo "  <details><summary>Linear drift (base to Linear)</summary>"
+                echo ""
+                echo '  ```diff'
+                diff <(echo "$base_body") <(echo "$linear_body") || true
+                echo '  ```'
+                echo "  </details>"
+                echo ""
+                any_changes=true
+              else
+                echo "- **$skill**: UPDATE (content differs)"
+                any_changes=true
+              fi
+            done
+
+            # Check for skills on Linear not in repo (orphans)
+            orphans=$(echo "$linear_skills" | jq -r --argjson repo "$(printf '%s\n' "${repo_skills[@]}" | jq -R . | jq -s .)" '[.[] | select(.title as $t | $repo | index($t) | not)] | .[].title')
+            if [ -n "$orphans" ]; then
+              echo ""
+              echo "**Orphaned skills on Linear** (not in repo):"
+              while IFS= read -r orphan; do
+                echo "- $orphan"
+              done <<< "$orphans"
+            fi
+
+            echo ""
+          done
+
+          if [ "$any_changes" = false ]; then
+            echo "No skill changes detected."
+          fi

--- a/.github/workflows/linear-skill-deploy.yaml
+++ b/.github/workflows/linear-skill-deploy.yaml
@@ -1,0 +1,194 @@
+name: Deploy skills to Linear
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-skills:
+    name: Deploy skills to Linear teams
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy skills
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_SKILL_TEAMS: ${{ vars.LINEAR_SKILL_TEAMS }}
+        run: |
+          set -euo pipefail
+
+          SKILLS_DIR="skills"
+
+          # --- noop guard ---
+
+          if [ -z "${LINEAR_API_KEY:-}" ] || [ -z "${LINEAR_SKILL_TEAMS:-}" ]; then
+            echo "Skipping skill deployment — LINEAR_API_KEY or LINEAR_SKILL_TEAMS not configured."
+            exit 0
+          fi
+
+          # --- helpers ---
+
+          gql() {
+            curl -sf -X POST https://api.linear.app/graphql \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $LINEAR_API_KEY" \
+              -d "$1"
+          }
+
+          fetch_team_skills() {
+            local team_id="$1"
+            local payload
+            payload=$(jq -nc --arg tid "$team_id" '{query: "{ agentSkills(filter: { team: { id: { eq: \"\($tid)\" } }, shared: { eq: true } }) { nodes { id title body } } }"}')
+            gql "$payload" | jq -r '.data.agentSkills.nodes // []'
+          }
+
+          resolve_team_id() {
+            local team_name="$1"
+            local payload
+            payload=$(jq -nc --arg name "$team_name" '{query: "{ teams(filter: { name: { eq: \"\($name)\" } }) { nodes { id name } } }"}')
+            gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
+          }
+
+          create_skill() {
+            local title="$1" body="$2" team_id="$3"
+            local payload
+            payload=$(jq -nc --arg t "$title" --arg b "$body" --arg tid "$team_id" \
+              '{query: "mutation($input: AgentSkillCreateInput!) { agentSkillCreate(input: $input) { success agentSkill { id title } } }", variables: {input: {title: $t, body: $b, teamId: $tid}}}')
+            gql "$payload"
+          }
+
+          update_skill() {
+            local id="$1" title="$2" body="$3"
+            local payload
+            payload=$(jq -nc --arg id "$id" --arg t "$title" --arg b "$body" \
+              '{query: "mutation($id: String!, $input: AgentSkillUpdateInput!) { agentSkillUpdate(id: $id, input: $input) { success agentSkill { id title } } }", variables: {id: $id, input: {title: $t, body: $b}}}')
+            gql "$payload"
+          }
+
+          delete_skill() {
+            local id="$1"
+            local payload
+            payload=$(jq -nc --arg id "$id" \
+              '{query: "mutation($id: String!) { agentSkillDelete(id: $id) { success } }", variables: {id: $id}}')
+            gql "$payload"
+          }
+
+          # --- discover skills from repo ---
+
+          repo_skills=()
+          for dir in "$SKILLS_DIR"/*/; do
+            skill=$(basename "$dir")
+            if [ -f "$dir/SKILL.md" ]; then
+              repo_skills+=("$skill")
+            fi
+          done
+
+          echo "Skills in repo: ${repo_skills[*]}"
+          echo ""
+
+          # --- iterate teams ---
+
+          IFS=',' read -ra TEAM_NAMES <<< "$LINEAR_SKILL_TEAMS"
+
+          created=0
+          updated=0
+          deleted=0
+          skipped=0
+          failed=0
+
+          for team_name in "${TEAM_NAMES[@]}"; do
+            team_name=$(echo "$team_name" | xargs)
+            team_id=$(resolve_team_id "$team_name")
+
+            if [ -z "$team_id" ]; then
+              echo "=== Team: $team_name (NOT FOUND — skipping) ==="
+              echo ""
+              continue
+            fi
+
+            echo "=== Team: $team_name ==="
+
+            linear_skills=$(fetch_team_skills "$team_id")
+
+            # Deploy repo skills
+            for skill in "${repo_skills[@]}"; do
+              skill_file="$SKILLS_DIR/$skill/SKILL.md"
+              file_body=$(cat "$skill_file")
+
+              linear_id=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .id // ""')
+              linear_body=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .body // ""')
+
+              if [ -z "$linear_id" ]; then
+                echo "  CREATE: $skill"
+                if result=$(create_skill "$skill" "$file_body" "$team_id" 2>&1); then
+                  success=$(echo "$result" | jq -r '.data.agentSkillCreate.success // false')
+                  if [ "$success" = "true" ]; then
+                    created=$((created + 1))
+                  else
+                    echo "  FAILED: $result"
+                    failed=$((failed + 1))
+                  fi
+                else
+                  echo "  FAILED: $result"
+                  failed=$((failed + 1))
+                fi
+              elif [ "$file_body" != "$linear_body" ]; then
+                echo "  UPDATE: $skill"
+                if result=$(update_skill "$linear_id" "$skill" "$file_body" 2>&1); then
+                  success=$(echo "$result" | jq -r '.data.agentSkillUpdate.success // false')
+                  if [ "$success" = "true" ]; then
+                    updated=$((updated + 1))
+                  else
+                    echo "  FAILED: $result"
+                    failed=$((failed + 1))
+                  fi
+                else
+                  echo "  FAILED: $result"
+                  failed=$((failed + 1))
+                fi
+              else
+                echo "  UP-TO-DATE: $skill"
+                skipped=$((skipped + 1))
+              fi
+            done
+
+            # Delete orphaned skills (on Linear but not in repo)
+            orphan_ids=$(echo "$linear_skills" | jq -r --argjson repo "$(printf '%s\n' "${repo_skills[@]}" | jq -R . | jq -s .)" '.[] | select(.title as $t | $repo | index($t) | not) | "\(.id)|\(.title)"')
+            if [ -n "$orphan_ids" ]; then
+              while IFS='|' read -r oid otitle; do
+                echo "  DELETE (orphan): $otitle"
+                if result=$(delete_skill "$oid" 2>&1); then
+                  success=$(echo "$result" | jq -r '.data.agentSkillDelete.success // false')
+                  if [ "$success" = "true" ]; then
+                    deleted=$((deleted + 1))
+                  else
+                    echo "  FAILED: $result"
+                    failed=$((failed + 1))
+                  fi
+                else
+                  echo "  FAILED: $result"
+                  failed=$((failed + 1))
+                fi
+              done <<< "$orphan_ids"
+            fi
+
+            echo ""
+          done
+
+          echo "=== Summary ==="
+          echo "Created: $created"
+          echo "Updated: $updated"
+          echo "Deleted: $deleted"
+          echo "Skipped: $skipped"
+          echo "Failed:  $failed"
+
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed skill deployments failed"
+            exit 1
+          fi

--- a/.github/workflows/linear-skill-deploy.yaml
+++ b/.github/workflows/linear-skill-deploy.yaml
@@ -36,23 +36,35 @@ jobs:
           # --- helpers ---
 
           gql() {
-            curl -sf -X POST https://api.linear.app/graphql \
+            local response
+            response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer $LINEAR_API_KEY" \
-              -d "$1"
+              -d "$1")
+            local http_code
+            http_code=$(echo "$response" | tail -1)
+            local body
+            body=$(echo "$response" | sed '$d')
+            if [ "$http_code" -ge 400 ]; then
+              echo "GraphQL error (HTTP $http_code): $body" >&2
+              return 1
+            fi
+            echo "$body"
           }
 
           fetch_team_skills() {
             local team_id="$1"
+            local q="{ agentSkills(filter: { team: { id: { eq: \"${team_id}\" } }, shared: { eq: true } }) { nodes { id title body } } }"
             local payload
-            payload=$(jq -nc --arg tid "$team_id" '{query: "{ agentSkills(filter: { team: { id: { eq: \"\($tid)\" } }, shared: { eq: true } }) { nodes { id title body } } }"}')
+            payload=$(jq -nc --arg q "$q" '{query: $q}')
             gql "$payload" | jq -r '.data.agentSkills.nodes // []'
           }
 
           resolve_team_id() {
             local team_name="$1"
+            local q="{ teams(filter: { name: { eq: \"${team_name}\" } }) { nodes { id name } } }"
             local payload
-            payload=$(jq -nc --arg name "$team_name" '{query: "{ teams(filter: { name: { eq: \"\($name)\" } }) { nodes { id name } } }"}')
+            payload=$(jq -nc --arg q "$q" '{query: $q}')
             gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
           }
 

--- a/.github/workflows/linear-skill-deploy.yaml
+++ b/.github/workflows/linear-skill-deploy.yaml
@@ -39,7 +39,7 @@ jobs:
             local response
             response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
               -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $LINEAR_API_KEY" \
+              -H "Authorization: $LINEAR_API_KEY" \
               -d "$1")
             local http_code
             http_code=$(echo "$response" | tail -1)

--- a/.github/workflows/linear-skill-deploy.yaml
+++ b/.github/workflows/linear-skill-deploy.yaml
@@ -6,6 +6,8 @@ on:
     # TODO: uncomment paths filter once verified — KB-37
     # paths:
     #   - 'skills/**'
+    #   - '.github/scripts/**'
+    #   - '.github/workflows/linear-skill-deploy.yaml'
 
 permissions:
   contents: read
@@ -17,191 +19,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: .github/scripts/package-lock.json
+
+      - name: Install deps
+        working-directory: .github/scripts
+        run: npm ci
+
+      # Run from the repo root so the script sees skills/ at cwd. Node resolves
+      # @linear/sdk from .github/scripts/node_modules via the script's own path.
       - name: Deploy skills
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_SKILL_TEAMS: ${{ vars.LINEAR_SKILL_TEAMS }}
-        run: |
-          set -euo pipefail
-
-          SKILLS_DIR="skills"
-
-          # --- noop guard ---
-
-          if [ -z "${LINEAR_API_KEY:-}" ] || [ -z "${LINEAR_SKILL_TEAMS:-}" ]; then
-            echo "Skipping skill deployment — LINEAR_API_KEY or LINEAR_SKILL_TEAMS not configured."
-            exit 0
-          fi
-
-          # --- helpers ---
-
-          gql() {
-            local response
-            response=$(curl -s -w "\n%{http_code}" -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$1")
-            local http_code
-            http_code=$(echo "$response" | tail -1)
-            local body
-            body=$(echo "$response" | sed '$d')
-            if [ "$http_code" -ge 400 ]; then
-              echo "GraphQL error (HTTP $http_code): $body" >&2
-              return 1
-            fi
-            echo "$body"
-          }
-
-          fetch_team_skills() {
-            local team_id="$1"
-            local q="{ agentSkills(filter: { team: { id: { eq: \"${team_id}\" } }, shared: { eq: true } }) { nodes { id title body } } }"
-            local payload
-            payload=$(jq -nc --arg q "$q" '{query: $q}')
-            gql "$payload" | jq -r '.data.agentSkills.nodes // []'
-          }
-
-          resolve_team_id() {
-            local team_name="$1"
-            local q="{ teams(filter: { name: { eq: \"${team_name}\" } }) { nodes { id name } } }"
-            local payload
-            payload=$(jq -nc --arg q "$q" '{query: $q}')
-            gql "$payload" | jq -r '.data.teams.nodes[0].id // ""'
-          }
-
-          create_skill() {
-            local title="$1" body="$2" team_id="$3"
-            local payload
-            payload=$(jq -nc --arg t "$title" --arg b "$body" --arg tid "$team_id" \
-              '{query: "mutation($input: AgentSkillCreateInput!) { agentSkillCreate(input: $input) { success agentSkill { id title } } }", variables: {input: {title: $t, body: $b, teamId: $tid}}}')
-            gql "$payload"
-          }
-
-          update_skill() {
-            local id="$1" title="$2" body="$3"
-            local payload
-            payload=$(jq -nc --arg id "$id" --arg t "$title" --arg b "$body" \
-              '{query: "mutation($id: String!, $input: AgentSkillUpdateInput!) { agentSkillUpdate(id: $id, input: $input) { success agentSkill { id title } } }", variables: {id: $id, input: {title: $t, body: $b}}}')
-            gql "$payload"
-          }
-
-          delete_skill() {
-            local id="$1"
-            local payload
-            payload=$(jq -nc --arg id "$id" \
-              '{query: "mutation($id: String!) { agentSkillDelete(id: $id) { success } }", variables: {id: $id}}')
-            gql "$payload"
-          }
-
-          # --- discover skills from repo ---
-
-          repo_skills=()
-          for dir in "$SKILLS_DIR"/*/; do
-            skill=$(basename "$dir")
-            if [ -f "$dir/SKILL.md" ]; then
-              repo_skills+=("$skill")
-            fi
-          done
-
-          echo "Skills in repo: ${repo_skills[*]}"
-          echo ""
-
-          # --- iterate teams ---
-
-          IFS=',' read -ra TEAM_NAMES <<< "$LINEAR_SKILL_TEAMS"
-
-          created=0
-          updated=0
-          deleted=0
-          skipped=0
-          failed=0
-
-          for team_name in "${TEAM_NAMES[@]}"; do
-            team_name=$(echo "$team_name" | xargs)
-            team_id=$(resolve_team_id "$team_name")
-
-            if [ -z "$team_id" ]; then
-              echo "=== Team: $team_name (NOT FOUND — skipping) ==="
-              echo ""
-              continue
-            fi
-
-            echo "=== Team: $team_name ==="
-
-            linear_skills=$(fetch_team_skills "$team_id")
-
-            # Deploy repo skills
-            for skill in "${repo_skills[@]}"; do
-              skill_file="$SKILLS_DIR/$skill/SKILL.md"
-              file_body=$(cat "$skill_file")
-
-              linear_id=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .id // ""')
-              linear_body=$(echo "$linear_skills" | jq -r --arg t "$skill" '.[] | select(.title == $t) | .body // ""')
-
-              if [ -z "$linear_id" ]; then
-                echo "  CREATE: $skill"
-                if result=$(create_skill "$skill" "$file_body" "$team_id" 2>&1); then
-                  success=$(echo "$result" | jq -r '.data.agentSkillCreate.success // false')
-                  if [ "$success" = "true" ]; then
-                    created=$((created + 1))
-                  else
-                    echo "  FAILED: $result"
-                    failed=$((failed + 1))
-                  fi
-                else
-                  echo "  FAILED: $result"
-                  failed=$((failed + 1))
-                fi
-              elif [ "$file_body" != "$linear_body" ]; then
-                echo "  UPDATE: $skill"
-                if result=$(update_skill "$linear_id" "$skill" "$file_body" 2>&1); then
-                  success=$(echo "$result" | jq -r '.data.agentSkillUpdate.success // false')
-                  if [ "$success" = "true" ]; then
-                    updated=$((updated + 1))
-                  else
-                    echo "  FAILED: $result"
-                    failed=$((failed + 1))
-                  fi
-                else
-                  echo "  FAILED: $result"
-                  failed=$((failed + 1))
-                fi
-              else
-                echo "  UP-TO-DATE: $skill"
-                skipped=$((skipped + 1))
-              fi
-            done
-
-            # Delete orphaned skills (on Linear but not in repo)
-            orphan_ids=$(echo "$linear_skills" | jq -r --argjson repo "$(printf '%s\n' "${repo_skills[@]}" | jq -R . | jq -s .)" '.[] | select(.title as $t | $repo | index($t) | not) | "\(.id)|\(.title)"')
-            if [ -n "$orphan_ids" ]; then
-              while IFS='|' read -r oid otitle; do
-                echo "  DELETE (orphan): $otitle"
-                if result=$(delete_skill "$oid" 2>&1); then
-                  success=$(echo "$result" | jq -r '.data.agentSkillDelete.success // false')
-                  if [ "$success" = "true" ]; then
-                    deleted=$((deleted + 1))
-                  else
-                    echo "  FAILED: $result"
-                    failed=$((failed + 1))
-                  fi
-                else
-                  echo "  FAILED: $result"
-                  failed=$((failed + 1))
-                fi
-              done <<< "$orphan_ids"
-            fi
-
-            echo ""
-          done
-
-          echo "=== Summary ==="
-          echo "Created: $created"
-          echo "Updated: $updated"
-          echo "Deleted: $deleted"
-          echo "Skipped: $skipped"
-          echo "Failed:  $failed"
-
-          if [ "$failed" -gt 0 ]; then
-            echo "::error::$failed skill deployments failed"
-            exit 1
-          fi
+        run: node .github/scripts/linear-skills.mjs deploy

--- a/.github/workflows/linear-skill-deploy.yaml
+++ b/.github/workflows/linear-skill-deploy.yaml
@@ -3,8 +3,9 @@ name: Deploy skills to Linear
 on:
   push:
     branches: [main]
-    paths:
-      - 'skills/**'
+    # TODO: uncomment paths filter once verified — KB-37
+    # paths:
+    #   - 'skills/**'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ devenv.local.nix
 # Direnv
 .envrc
 dispatch-runs/
+
+# Node (CI tooling under .github/scripts)
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ devenv.local.nix
 
 # Direnv
 .envrc
+dispatch-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ devenv.local.nix
 
 # Direnv
 .envrc
-dispatch-runs/
 
 # Node (CI tooling under .github/scripts)
 node_modules/

--- a/skills/linearissue/SKILL.md
+++ b/skills/linearissue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: linearissue
 description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue, OR when the user wants to create a new issue freeform (without a design note). Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Freeform mode triggers: 'create an issue for X', 'file a ticket about Y', 'new issue: Z', 'ticket this', or any request to create a Linear issue without referencing a design note or existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from records in `status: decided` (decisions are made; they don't spawn tickets — only `status: exploring` records have actionable items), or for any operation that would also commit to git."
-api_description: "File action items from a design note as Linear issues with bidirectional cross-references and idempotent re-runs, iterate on an existing Linear issue by posting analysis, context, or refinements as comments, or create new issues freeform with title quality enforcement. Three modes: filing (from a note), iteration (from a ticket ID or URL), and freeform (from a prompt)."
+api_description: "File action items from a design note as Linear issues with bidirectional cross-references and idempotent re-runs, iterate on an existing Linear issue by posting analysis, context, or refinements as comments, or create new issues freeform. All titles must pass a mandatory checklist: imperative voice, verb from tiered list, [VERB] [NOUN] [CONTEXT] structure, cold-reader test. Three modes: filing (from a note), iteration (from a ticket ID or URL), and freeform (from a prompt)."
 allowed-tools: Bash Glob Grep Read Edit WebFetch AskUserQuestion Skill mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__search_pull_requests
 ---
 
@@ -170,7 +170,7 @@ Parse the note for action items. Canonical sources, in priority order:
 
 For each candidate, capture:
 
-- **Title:** the first line of the item, cleaned up (strip checklist markers, leading "TODO:", trailing punctuation). Run through the **title quality gate** — if the gate fires, store both the original and suggested rewrite for presentation in Phase 3.
+- **Title:** the first line of the item, cleaned up (strip checklist markers, leading "TODO:", trailing punctuation). Run through the **title quality gate pre-presentation checklist** — imperative `[VERB] [NOUN] [CONTEXT]`, verb from tier list, cold-reader check. If the gate fires, store both the original and suggested rewrite for presentation in Phase 3.
 - **Description:** the item's body content + the parent section heading + up to ~10 lines of preceding contextual prose from the section. Quote rather than paraphrase.
 - **Source anchor:** `{relative-note-path}#{slugified-section-heading}` so the Linear ticket can deep-link back.
 - **Tags from the note's front matter** — these may inform Linear labels.
@@ -369,7 +369,7 @@ Read the user's prompt and extract:
 
 For each item, draft:
 
-- **Title** — derive from the user's description, then run through the **title quality gate**. If the gate fires, present the original and suggested rewrite.
+- **Title** — derive from the user's description, then run the **title quality gate pre-presentation checklist**: imperative `[VERB] [NOUN] [CONTEXT]`, verb from tier list, cold-reader check. If the gate fires, present the original and suggested rewrite.
 - **Description** — 2–5 sentences maximum: what the work is, why it matters (if not obvious), and a **DoD** sentence ("Done when X is true/observable/verifiable"). Prepend `*[ai:claude-code]*` as the first line. Keep it minimal — the anchor principle applies just as in filing mode.
 - **Priority** — infer from the user's language (urgent, blocker, nice-to-have, etc.). Default Normal.
 - **Labels** — infer from context (e.g. "bug" → Bug label, "research" → Research label). Only apply if confident.
@@ -446,9 +446,22 @@ Print:
 
 ## Title quality gate
 
+> **IMPERATIVE. ALWAYS.** Every title is `[VERB] [NOUN] [CONTEXT]` — a task someone does, not a statement someone reads. Verb from the tier list below. No exceptions. Run the checklist before presenting any title.
+
 Every title — whether derived from a design note action item, drafted in freeform mode, or proposed as an iteration refinement — must pass through this gate. The gate is **advisory**: warn and suggest, never block.
 
 > **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is linearissue-specific) but the core principles and examples should match.
+
+### Pre-presentation checklist
+
+Run this mechanically before presenting any title to the user. Every box must pass.
+
+1. **Imperative voice?** — Is this a task (verb + object), not a statement or noun phrase? "Enforce X" yes, "X enforcement" no, "X across surfaces" no.
+2. **Verb from tier 1 or 2?** — Check the verb against the tier list below. Tier 3 = rewrite.
+3. **Structure: `[VERB] [NOUN] [CONTEXT]`?** — Verb first, differentiating noun second, narrowing context third.
+4. **Cold read matches intent?** — Would a stranger scanning this title understand the task without conversation context?
+5. **Under 72 chars?**
+6. **Distinguishable at 30 chars from siblings?** — Only when filing multiple related tickets.
 
 ### Canonical structure
 


### PR DESCRIPTION
## Summary

- Pre-merge workflow (`linear-skill-check`) surfaces what would change per team: CREATE, UPDATE, DELETE, DRIFT (manual Linear edits), CONFLICT (both changed)
- Post-merge workflow (`linear-skill-deploy`) upserts all `skills/*/SKILL.md` to listed teams via Linear GraphQL API, deletes orphans
- Config via GH secret `LINEAR_API_KEY` + variable `LINEAR_SKILL_TEAMS` (comma-separated team names, resolved to IDs at runtime)
- Graceful noop when either var is missing (fork-friendly)

Closes KB-37

## Test plan

- [ ] Verify `LINEAR_SKILL_TEAMS` repo variable is set (`vidbina,zero`)
- [ ] Verify pre-merge check runs on this PR and reports skill status per team
- [ ] After merge, verify deploy workflow creates skills on Linear teams
- [ ] Check Linear team settings to confirm skills appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)