### PR TITLE
Rename skills to platform-agnostic imperative names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 
 ---
 
+## [2026-06-15]
+
+### Changed
+- **Skills renamed to platform-agnostic imperative names** — five skill directories were renamed so the invocation matches the artifact or task, not the platform or grammar: `commenting` → `comment`, `commitmsg` → `commit`, `designnote` → `decision`, `linearissue` → `issue`, `pairprog` → `pair`. Cross-references between skills, `Skill("…")` call sites, `/`-invocation examples, and `skills/README.md` were updated to the new names. This is a rename only — skill behavior, descriptions, and bodies are otherwise unchanged.
+
+### Migration
+
+**Files:**
+- If your project vendors copies of any renamed skill (`skills/commenting`, `skills/commitmsg`, `skills/designnote`, `skills/linearissue`, `skills/pairprog`), move them to the new directory names and update any internal `Skill("…")` references.
+
+**Tooling / habits:**
+- Invoke the skills under their new names: `/comment`, `/commit`, `/decision`, `/issue`, `/pair`.
+
+**CI/CD:**
+- The Linear skill deploy (`.github/workflows/linear-skill-deploy.yaml`) derives each skill's Linear title from its directory name. On the next deploy this rename creates the five new skill entries and deletes the old ones — no manual action needed, but expect the corresponding Linear AI skills to be re-created under the new titles.
+
 ## [2026-06-13]
 
 ### Changed

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,11 +6,11 @@ Claude Code skills that operate on KB-defined artifacts (decision records, TODO.
 
 | Skill | Purpose | KB artifacts touched |
 |-------|---------|---------------------|
-| **commenting** | Post structured comments to Linear issues (threading, provenance, formatting) | None (protocol only) |
-| **commitmsg** | Suggest commit messages following repo conventions | Reads CONTRIBUTING.md, AGENTS.md |
-| **designnote** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
-| **linearissue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
-| **pairprog** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |
+| **comment** | Post structured comments to Linear issues (threading, provenance, formatting) | None (protocol only) |
+| **commit** | Suggest commit messages following repo conventions | Reads CONTRIBUTING.md, AGENTS.md |
+| **decision** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
+| **issue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
+| **pair** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |
 | **pr** | Create pull requests with smart base branch detection | Reads Linear tickets |
 
 ## Skills that stay in dotfiles
@@ -25,12 +25,12 @@ The dotfiles repo symlinks each skill directory into `claude/skills/`:
 
 ```bash
 # In dotfiles/claude/skills/
-commenting  -> <PATH_TO_KB_REPO>/skills/commenting
-commitmsg   -> <PATH_TO_KB_REPO>/skills/commitmsg
-designnote  -> <PATH_TO_KB_REPO>/skills/designnote
-linearissue -> <PATH_TO_KB_REPO>/skills/linearissue
-pairprog    -> <PATH_TO_KB_REPO>/skills/pairprog
-pr          -> <PATH_TO_KB_REPO>/skills/pr
+comment  -> <PATH_TO_KB_REPO>/skills/comment
+commit   -> <PATH_TO_KB_REPO>/skills/commit
+decision -> <PATH_TO_KB_REPO>/skills/decision
+issue    -> <PATH_TO_KB_REPO>/skills/issue
+pair     -> <PATH_TO_KB_REPO>/skills/pair
+pr       -> <PATH_TO_KB_REPO>/skills/pr
 ```
 
 `mkOutOfStoreSymlink` in nix-darwin follows the symlink chain — no config changes needed.

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -34,7 +34,7 @@ KB repo (source of truth)
   │
   ├── File migrations → Edit/Write directly
   ├── Repo settings → surface gh CLI commands (HITL)
-  ├── Ticket migrations → /linearissue for title/scope fixes
+  ├── Ticket migrations → /issue for title/scope fixes
   └── Manual steps → surface instructions, can't automate
 ```
 
@@ -167,11 +167,11 @@ Step 5: 🔧 EXTERNAL — Set squash-merge title to "PR title" (manual)
 
 ### File tracking ticket
 
-Before executing any migrations, file a tracking ticket via `/linearissue` scoped to the gaps found in Phase 2. Title format: `Align conventions to KB YYYY-MM-DD state` (or more specific if only a subset of entries apply). The ticket description should list the migration steps as a checklist.
+Before executing any migrations, file a tracking ticket via `/issue` scoped to the gaps found in Phase 2. Title format: `Align conventions to KB YYYY-MM-DD state` (or more specific if only a subset of entries apply). The ticket description should list the migration steps as a checklist.
 
 If the operator prefers not to file a ticket (e.g. the alignment is trivial), skip — but offer it. For non-trivial runs (3+ steps, destructive operations, ticket audits), strongly recommend it.
 
-Store the ticket ID — all Phase 3 progress comments thread on it via `/commenting`.
+Store the ticket ID — all Phase 3 progress comments thread on it via `/comment`.
 
 ## Phase 3 — Execute migrations
 
@@ -206,10 +206,10 @@ For each approved step:
 2. **Execute** the change:
    - **File changes:** `Edit` / `Write` / `Bash` (for `git mv`, `git rm`)
    - **Repo settings:** surface `gh` CLI commands for the operator. On explicit approval ("go ahead"), execute them. Never auto-execute external changes.
-   - **Ticket changes:** delegate to the `/linearissue` skill for title rewrites and scope fixes. Present proposed changes and get approval before applying.
+   - **Ticket changes:** delegate to the `/issue` skill for title rewrites and scope fixes. Present proposed changes and get approval before applying.
    - **Manual steps:** print instructions clearly. Mark as done only when the operator confirms they've completed it.
 3. **Verify** the step succeeded — re-run the gap check for that specific item.
-4. **Comment progress** — if a tracking ticket was filed, post a progress comment via `/commenting` threaded on it. Include what was done, what resource type it affected, and any decisions made (e.g. "operator chose to keep original title for KB-14"). This builds the audit trail.
+4. **Comment progress** — if a tracking ticket was filed, post a progress comment via `/comment` threaded on it. Include what was done, what resource type it affected, and any decisions made (e.g. "operator chose to keep original title for KB-14"). This builds the audit trail.
 5. **Mark complete** and move to the next step.
 
 ### Defensive measures
@@ -248,11 +248,11 @@ Files changed: {list}
 Suggested commit: doc: align repo conventions to KB standards [YYYY-MM-DD] [ai:claude]
 ```
 
-Do not commit — git is HITL. Present the suggested commit message using `commitmsg` methodology.
+Do not commit — git is HITL. Present the suggested commit message using `commit` methodology.
 
 ### Close the tracking ticket
 
-If a tracking ticket was filed in Phase 2, post a resolution comment via `/commenting` with the full summary above (applied, manual, skipped, tickets audited). This is the audit record — anyone reviewing the alignment run later sees exactly what was checked, what was changed, and what decisions the operator made.
+If a tracking ticket was filed in Phase 2, post a resolution comment via `/comment` with the full summary above (applied, manual, skipped, tickets audited). This is the audit record — anyone reviewing the alignment run later sees exactly what was checked, what was changed, and what decisions the operator made.
 
 Transition the ticket to Done if all steps are complete (including manual ones confirmed by the operator). If manual steps remain, leave it In Progress with the outstanding items listed in the comment.
 

--- a/skills/comment/SKILL.md
+++ b/skills/comment/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: commenting
-description: "Use this skill when another skill or the user needs to post a structured comment to a Linear issue. This skill owns the commenting protocol: thread lifecycle (anchor → replies → resolution), provenance markers, formatting, and threading via parentId. Trigger when a skill wants to post an assessment, finding, plan, status update, or session summary to a Linear issue. Also trigger when the user invokes `/commenting`. Do NOT use this skill for reading comments (use list_comments directly) or for creating/updating issues (use save_issue directly). This skill only handles comment creation with proper formatting and threading."
+name: comment
+description: "Use this skill when another skill or the user needs to post a structured comment to a Linear issue. This skill owns the commenting protocol: thread lifecycle (anchor → replies → resolution), provenance markers, formatting, and threading via parentId. Trigger when a skill wants to post an assessment, finding, plan, status update, or session summary to a Linear issue. Also trigger when the user invokes `/comment`. Do NOT use this skill for reading comments (use list_comments directly) or for creating/updating issues (use save_issue directly). This skill only handles comment creation with proper formatting and threading."
 api_description: "Post structured comments to Linear issues following a uniform protocol: thread anchors, threaded replies, provenance markers, and resolution semantics. Handles formatting and threading so calling skills don't have to."
 allowed-tools: mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__get_issue
 ---
 
-# commenting
+# comment
 
 Post structured comments to Linear issues. This skill owns the **how** of commenting — formatting, provenance, threading. Calling skills own the **what** — when to comment and what content to include.
 
@@ -34,7 +34,7 @@ Every comment has three parts:
 Example:
 
 ```markdown
-**Assessment** (pairprog)
+**Assessment** (pair)
 
 *[ai:claude-code]*
 
@@ -47,7 +47,7 @@ Example:
 
 - **Anchor:** A top-level comment that starts a thread. One anchor per logical unit of work (one assessment, one spike, one plan, one session summary). Post with `save_comment(issueId, body)`.
 - **Reply:** A threaded response under an anchor. Used for updates, completions, and corrections to the anchor's unit of work. Post with `save_comment(issueId, body, parentId)` where `parentId` is the anchor's comment ID.
-- **Resolution:** The final reply in a thread. Prefix the heading with ✅ to signal completion: `**✅ Step 1 complete** (pairprog)`. (Linear MCP doesn't expose `resolvedAt`, so the emoji is the visual signal.)
+- **Resolution:** The final reply in a thread. Prefix the heading with ✅ to signal completion: `**✅ Step 1 complete** (pair)`. (Linear MCP doesn't expose `resolvedAt`, so the emoji is the visual signal.)
 
 ### When to anchor vs reply
 
@@ -79,12 +79,12 @@ When something changes mid-thread (plan adjusted, step skipped, blocker found), 
 
 ## Interface
 
-Calling skills invoke this skill via `Skill("commenting", args)` where `args` is a natural-language instruction. The commenting skill parses the intent and calls `save_comment` with proper formatting.
+Calling skills invoke this skill via `Skill("comment", args)` where `args` is a natural-language instruction. The comment skill parses the intent and calls `save_comment` with proper formatting.
 
 ### Anchor examples
 
 ```
-Post an anchor comment on VID-123 titled "Assessment" from skill "pairprog" with body:
+Post an anchor comment on VID-123 titled "Assessment" from skill "pair" with body:
 
 **Clear and ready:**
 - Item 1
@@ -107,7 +107,7 @@ The config file is missing the API key entry.
 ### Reply examples
 
 ```
-Reply to anchor {comment-id} on VID-123 titled "Step 1 complete" from skill "pairprog" with body:
+Reply to anchor {comment-id} on VID-123 titled "Step 1 complete" from skill "pair" with body:
 
 Added OAuth callback route in `src/routes/auth.ts`.
 Test added — passing.
@@ -115,7 +115,7 @@ Commit: `a1b2c3d`
 ```
 
 ```
-Reply to anchor {comment-id} on VID-123 titled "🚨 Plan adjusted" from skill "pairprog" with body:
+Reply to anchor {comment-id} on VID-123 titled "🚨 Plan adjusted" from skill "pair" with body:
 
 Step 3 replaced with Step 3a: explicit re-login flow.
 Reason: navigator decided silent refresh adds complexity.
@@ -124,7 +124,7 @@ Reason: navigator decided silent refresh adds complexity.
 ### Resolution example
 
 ```
-Reply to anchor {comment-id} on VID-123 titled "✅ Session complete" from skill "pairprog" with body:
+Reply to anchor {comment-id} on VID-123 titled "✅ Session complete" from skill "pair" with body:
 
 **Completed:**
 - [x] Step 1: OAuth callback route

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: commitmsg
-description: "Use this skill when the user asks for a commit message suggestion based on their current uncommitted changes — or when the user invokes `/commitmsg`. Trigger for prompts like 'suggest a commit message', 'commitmsg', 'what should I commit this as', 'draft a commit', 'write a commit message for this'. The skill reads the repo's own docs (CONTRIBUTING.md, AGENTS.md, README.md) and the org knowledge base (via `./kb` or `./knowledge-base` symlink if present) for commit conventions, inspects the uncommitted diff and recent git history, and prints a suggested commit message in chat. It never commits, stages, or modifies files in normal mode. It also has a setup mode (`--setup`) that inspects git history, repo docs, and the org kb to draft or update the commit convention section in the repo's docs — run this once per repo to bootstrap the convention. Do NOT trigger for actually committing (the user runs git commit themselves), for amending or rebasing (those are direct git operations), for generating changelogs or release notes (different task), or for reviewing code (use a review skill or do it directly)."
+name: commit
+description: "Use this skill when the user asks for a commit message suggestion based on their current uncommitted changes — or when the user invokes `/commit`. Trigger for prompts like 'suggest a commit message', 'commit', 'what should I commit this as', 'draft a commit', 'write a commit message for this'. The skill reads the repo's own docs (CONTRIBUTING.md, AGENTS.md, README.md) and the org knowledge base (via `./kb` or `./knowledge-base` symlink if present) for commit conventions, inspects the uncommitted diff and recent git history, and prints a suggested commit message in chat. It never commits, stages, or modifies files in normal mode. It also has a setup mode (`--setup`) that inspects git history, repo docs, and the org kb to draft or update the commit convention section in the repo's docs — run this once per repo to bootstrap the convention. Do NOT trigger for actually committing (the user runs git commit themselves), for amending or rebasing (those are direct git operations), for generating changelogs or release notes (different task), or for reviewing code (use a review skill or do it directly)."
 api_description: "Generate a commit message for the current staged diff, following the repo's documented conventions. Reads CONTRIBUTING.md, recent git history, and any org knowledge base for style. Never commits, stages, or modifies files."
 allowed-tools: Bash Glob Grep Read Write Edit AskUserQuestion
 ---
 
-# commitmsg
+# commit
 
 Suggest a **commit message** for the user's current uncommitted changes, following the conventions documented in the repo itself.
 
@@ -41,7 +41,7 @@ Search for commit convention documentation. Check these sources in order, collec
 
 If none of these sources contain commit convention guidance, warn the user:
 
-> No commit convention found in this repo's docs. Run `/commitmsg --setup` to bootstrap one from git history and the org kb, or I'll fall back to describing the changes without a specific format.
+> No commit convention found in this repo's docs. Run `/commit --setup` to bootstrap one from git history and the org kb, or I'll fall back to describing the changes without a specific format.
 
 Proceed with a plain descriptive message if the user doesn't want to set up.
 

--- a/skills/decision/SKILL.md
+++ b/skills/decision/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: designnote
-description: "Use this skill when the user asks you to start, extend, or record a decision record — ideation around a design problem, architectural choice, trade-off analysis, open question, or a decision that needs long-term awareness. Trigger for prompts like 'take a note on X', 'design note for X', 'let's think through X', 'capture the options for X', 'document this decision', 'explore trade-offs for X', 'start a dnote for X', 'write up the problem of X', 'we should think about X and park it', 'note the constraints around X', 'ideate on X'. Also trigger when the user invokes `/designnote`. The skill reads existing records, related Linear tickets, and the repo's TODO.md, researches open questions in parallel via subagents, and writes (or extends) a decision record in `docs/decisions/` — OR, for strategy/process/team-facing content, a Linear document. It batches clarifying questions into ONE up-front round so the user can walk away and return to a finished artifact. Do NOT trigger for quick factual questions (use qsearch or answer directly), for code changes (just do the work), for small one-liners that belong in TODO.md (add the line directly without invoking the skill), for operational status updates on existing Linear tickets, or for creating Linear issues from an existing record's action items (that's the linearissue skill)."
+name: decision
+description: "Use this skill when the user asks you to start, extend, or record a decision record — ideation around a design problem, architectural choice, trade-off analysis, open question, or a decision that needs long-term awareness. Trigger for prompts like 'take a note on X', 'design note for X', 'let's think through X', 'capture the options for X', 'document this decision', 'explore trade-offs for X', 'start a dnote for X', 'write up the problem of X', 'we should think about X and park it', 'note the constraints around X', 'ideate on X'. Also trigger when the user invokes `/decision`. The skill reads existing records, related Linear tickets, and the repo's TODO.md, researches open questions in parallel via subagents, and writes (or extends) a decision record in `docs/decisions/` — OR, for strategy/process/team-facing content, a Linear document. It batches clarifying questions into ONE up-front round so the user can walk away and return to a finished artifact. Do NOT trigger for quick factual questions (use qsearch or answer directly), for code changes (just do the work), for small one-liners that belong in TODO.md (add the line directly without invoking the skill), for operational status updates on existing Linear tickets, or for creating Linear issues from an existing record's action items (that's the issue skill)."
 api_description: "Draft or extend a decision record documenting a problem, options considered, trade-offs, and chosen approach. Writes to docs/decisions/ or a Linear document depending on scope. Researches open questions in parallel and batches clarifying questions into one up-front round."
 allowed-tools: Task WebSearch WebFetch AskUserQuestion Glob Grep Read Write Edit mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__save_document mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__search_documentation
 ---
 
-# designnote
+# decision
 
 Draft or extend a **decision record** — a living, evolving document that records a problem, the options considered, the reasoning, the chosen approach, and any open questions that may be revisited. Decision records are the canonical surface for long-lived architectural thinking in this workflow. Records start in `status: exploring` and graduate to `status: decided` when the decision is made.
 
@@ -17,7 +17,7 @@ The defining design principles of this skill are:
 >
 > **Prefer extending an existing record to creating a new one. Duplication erodes the knowledge base.**
 
-The user should be able to kick this off, answer a small batch of up-front questions, walk away, and return to a decision record they can review, edit, and then hand off to the `linearissue` skill for execution.
+The user should be able to kick this off, answer a small batch of up-front questions, walk away, and return to a decision record they can review, edit, and then hand off to the `issue` skill for execution.
 
 ## How this fits the broader workflow
 
@@ -25,19 +25,19 @@ The user should be able to kick this off, answer a small batch of up-front quest
 prompt
   │
   ▼
-designnote skill  →  decision record (with action items in canonical sections)   ← you are here
+decision skill  →  decision record (with action items in canonical sections)   ← you are here
   │
   ▼
 [HITL gate: human reviews, edits, greenlights the record]
   │
   ▼
-linearissue       →  proposes tickets in chat → confirms via AskUserQuestion → creates tickets
+issue       →  proposes tickets in chat → confirms via AskUserQuestion → creates tickets
   │
   ▼
 Linear: LIN-NNN annotations written back into the record
 ```
 
-This skill produces the artifact that `linearissue` consumes. The two skills share no runtime state — the decision record file is the only interface between them. After `designnote` finishes, the human reviews and edits the record. Only then does `linearissue` read it.
+This skill produces the artifact that `issue` consumes. The two skills share no runtime state — the decision record file is the only interface between them. After `decision` finishes, the human reviews and edits the record. Only then does `issue` read it.
 
 ## Context on the artifact
 
@@ -126,7 +126,7 @@ Write out the routing decision explicitly in your Phase 4 "locked decisions" com
 
 ### Rename the session
 
-After interpreting the prompt, rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name is a 2–4 word summary of the design topic — e.g. "card layout abstraction (designnote)" or "VID-123 auth token storage (designnote)" if a ticket is related.
+After interpreting the prompt, rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name is a 2–4 word summary of the design topic — e.g. "card layout abstraction (decision)" or "VID-123 auth token storage (decision)" if a ticket is related.
 
 If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it — but don't block on this. Move on to scope discovery either way.
 
@@ -272,7 +272,7 @@ If a claim genuinely has no linkable source (e.g. a conclusion you reasoned to, 
 
    | Status | Date       | Author | Related Tickets | Notes                         |
    | :----- | :--------- | :----- | :-------------- | :---------------------------- |
-   | TODO   | YYYY-MM-DD | claude | [LIN-NNN](...)  | Initial creation via designnote |
+   | TODO   | YYYY-MM-DD | claude | [LIN-NNN](...)  | Initial creation via decision |
 
    ## Context
 
@@ -296,7 +296,7 @@ If a claim genuinely has no linkable source (e.g. a conclusion you reasoned to, 
    ```
 
 4. **Populate** with findings from the research phase. Add custom sections as needed: `## Open Questions`, `## Trigger Points`, `## Upstream References`, `## Related Design Notes`. Match the richer style of existing records in the repo if they follow one.
-5. **Action items.** If the research surfaces concrete follow-up work, add a `## Action items` section with checklist items. These are the hooks the `linearissue` skill will find later. When structuring action items, be aware of the decomposition-vs-dependency distinction: items that represent parts of one goal (same person, same work stream) can be grouped under a parent item, but items that represent different goals gating each other (different person, different work) should be flat peers with explicit "blocked by" / "depends on" language — not nested sub-items. The `linearissue` skill uses this structure to decide between sub-issues and blocking relations. Getting it wrong here creates misleading progress counters and merge chain hell downstream.
+5. **Action items.** If the research surfaces concrete follow-up work, add a `## Action items` section with checklist items. These are the hooks the `issue` skill will find later. When structuring action items, be aware of the decomposition-vs-dependency distinction: items that represent parts of one goal (same person, same work stream) can be grouped under a parent item, but items that represent different goals gating each other (different person, different work) should be flat peers with explicit "blocked by" / "depends on" language — not nested sub-items. The `issue` skill uses this structure to decide between sub-issues and blocking relations. Getting it wrong here creates misleading progress counters and merge chain hell downstream.
 6. **Set `review_date`** to 3 months from today by default. Adjust if the topic is time-sensitive (shorter) or foundational (longer).
 
 ### Extend existing record
@@ -327,7 +327,7 @@ Print a concise summary:
 - **Tags used:** with reuse-or-mint justification for each
 - **Related discovered:** Linear tickets, related notes, TODO.md stubs that informed the work
 - **Open questions captured:** count and pointer to the section
-- **Suggested next step:** e.g., "Review the note, edit as needed, then run `/linearissue` on this path to file tickets from the action items."
+- **Suggested next step:** e.g., "Review the note, edit as needed, then run `/issue` on this path to file tickets from the action items."
 - **Suggested commit message** following the repo's convention (if the repo's `CLAUDE.md` documents one). Include an `[ai:claude]` tag if that's the repo convention. **Do not commit** — git is HITL.
 
 If any research step failed or was skipped (e.g., web unavailable, Linear MCP absent), flag it clearly in both the wrap-up and the note's Status Log.
@@ -346,8 +346,8 @@ If any research step failed or was skipped (e.g., web unavailable, Linear MCP ab
 - **Don't ask more than one round of clarification.** Phase 3 is the only interruption. Anything that surfaces mid-research goes into the note's `## Open Questions` section and the run continues.
 - **Don't silently fall back to training data.** If web research fails and the prompt requires fresh info, flag it in the Status Log notes column and in the wrap-up.
 - **Don't assume repo conventions.** If `docs/decisions/` doesn't exist, ask the user whether to bootstrap or bail. Don't create the directory silently.
-- **Don't replicate action items elsewhere.** The design note is the single source of truth. No parallel work-plan files, no task list extractions, no duplicate representations. The `linearissue` skill will consume the note directly.
-- **Don't pre-mint ticket IDs.** The note carries action items in plain markdown. Linear IDs are written back by `linearissue` after tickets exist, not before.
+- **Don't replicate action items elsewhere.** The design note is the single source of truth. No parallel work-plan files, no task list extractions, no duplicate representations. The `issue` skill will consume the note directly.
+- **Don't pre-mint ticket IDs.** The note carries action items in plain markdown. Linear IDs are written back by `issue` after tickets exist, not before.
 - **Don't interpret "create a design note" as license to create churn.** If an existing note covers the scope, extend it. If a TODO.md one-liner would suffice, just add the line. The warrants-a-note test is: (a) involves a choice with trade-offs, (b) has open questions worth parking, or (c) couples to other architectural concerns. If fewer than one applies, it's probably a TODO.md line.
 
 ## Required grants

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: linearissue
-description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue, OR when the user wants to create a new issue freeform (without a design note). Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Freeform mode triggers: 'create an issue for X', 'file a ticket about Y', 'new issue: Z', 'ticket this', or any request to create a Linear issue without referencing a design note or existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from records in `status: decided` (decisions are made; they don't spawn tickets — only `status: exploring` records have actionable items), or for any operation that would also commit to git."
+name: issue
+description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue, OR when the user wants to create a new issue freeform (without a design note). Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'issue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Freeform mode triggers: 'create an issue for X', 'file a ticket about Y', 'new issue: Z', 'ticket this', or any request to create a Linear issue without referencing a design note or existing issue. Also trigger when the user invokes `/issue`. Do NOT trigger for creating Linear documents (that's the decision skill's strategy-routing path), for filing tickets from records in `status: decided` (decisions are made; they don't spawn tickets — only `status: exploring` records have actionable items), or for any operation that would also commit to git."
 api_description: "File action items from a design note as Linear issues with bidirectional cross-references and idempotent re-runs, iterate on an existing Linear issue by posting analysis, context, or refinements as comments, or create new issues freeform. All titles must pass a mandatory checklist: imperative voice, verb from tiered list, [VERB] [NOUN] [CONTEXT] structure, cold-reader test. Three modes: filing (from a note), iteration (from a ticket ID or URL), and freeform (from a prompt)."
 allowed-tools: Bash Glob Grep Read Edit WebFetch AskUserQuestion Skill mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__search_pull_requests
 ---
 
-# linearissue
+# issue
 
 Create Linear issues — from a design note's action items, from an existing ticket (iteration), or freeform from a prompt. All modes enforce value-oriented titles via a quality gate, use an in-chat confirmation gate, and support idempotent re-runs.
 
@@ -25,13 +25,13 @@ The defining design principles of this skill are:
 prompt
   │
   ▼
-designnote skill  →  design note (with action items in canonical sections)
+decision skill  →  design note (with action items in canonical sections)
   │
   ▼
 [HITL gate: human reviews, edits, greenlights the note]
   │
   ▼
-linearissue       →  prints proposed tickets in chat
+issue       →  prints proposed tickets in chat
   │
   ▼
 [HITL gate: AskUserQuestion confirmation]
@@ -40,7 +40,7 @@ linearissue       →  prints proposed tickets in chat
 creates tickets + writes Linear: LIN-NNN annotations back into the note
 ```
 
-The human gate on the design note itself is where the real review happens. By the time `linearissue` runs, the note is greenlit — ticket derivation is mechanical. The in-chat confirmation is a final sanity check, not a deep review.
+The human gate on the design note itself is where the real review happens. By the time `issue` runs, the note is greenlit — ticket derivation is mechanical. The in-chat confirmation is a final sanity check, not a deep review.
 
 ## Tools declared in allowed-tools
 
@@ -49,7 +49,7 @@ The human gate on the design note itself is where the real review happens. By th
 - `WebFetch` — follow URLs referenced in the note when enriching ticket descriptions
 - `AskUserQuestion` — the confirmation gate (and batched clarification if needed)
 - Linear MCP read tools — search for existing tickets, resolve teams/projects, look up statuses and labels
-- `Skill` — invoke the `commenting` skill for posting comments to Linear issues
+- `Skill` — invoke the `comment` skill for posting comments to Linear issues
 - Linear MCP write tools — `save_issue`
 
 The skill does not declare `Task` — there is no parallel research phase. Ticket derivation is deterministic and serial.
@@ -70,13 +70,13 @@ Examine the first argument (or the full prompt if no explicit argument):
 
 After detecting the mode, rename the session to reflect the scope:
 
-Rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name reflects the mode and scope — e.g. "card layout abstraction (linearissue)" for filing, "VID-123 OAuth2 Google login (linearissue:iterate)" for iteration, or "auth token storage (linearissue:freeform)" for freeform.
+Rename the session so the user can identify it at a glance (e.g. in a terminal tab). A good name reflects the mode and scope — e.g. "card layout abstraction (issue)" for filing, "VID-123 OAuth2 Google login (issue:iterate)" for iteration, or "auth token storage (issue:freeform)" for freeform.
 
 If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it — but don't block on this. Move on to the next phase either way.
 
 ### Triage: check for duplicates and scope overlap
 
-Before creating any new issue — whether from a design note or freeform — run a tiered check to avoid duplicates, scope overlap, and contradictions in the backlog. This applies in both filing mode and when other skills (pairprog, freeform conversation) route through `save_issue` to create a ticket.
+Before creating any new issue — whether from a design note or freeform — run a tiered check to avoid duplicates, scope overlap, and contradictions in the backlog. This applies in both filing mode and when other skills (pair, freeform conversation) route through `save_issue` to create a ticket.
 
 **Tier 0 — Project fit (always run, before anything else):**
 
@@ -118,11 +118,11 @@ Only proceed to filing after the user confirms the triage result.
 **Every ticket state change that removes a ticket from the active backlog (Cancelled, Duplicate) must carry a comment explaining why.** A cancelled ticket with no explanation is a dead end for anyone reviewing the backlog later — they can't tell if it was superseded, descoped, invalid, or accidentally closed.
 
 When cancelling or duplicating a ticket:
-1. Post a comment via `/commenting` with a heading like "Cancelled: {reason}" or "Duplicated by {TICKET-ID}"
+1. Post a comment via `/comment` with a heading like "Cancelled: {reason}" or "Duplicated by {TICKET-ID}"
 2. Include a one-sentence explanation of why (e.g. "KB-36 bundles this rename with two others — same mechanical pattern, one ticket instead of three")
 3. If superseded by another ticket, reference it so readers can follow the chain
 
-This rule applies regardless of which skill triggers the cancellation — `/linearissue` triage, `/pairprog` scope discovery, or manual operator action. If the operator cancels directly, suggest the comment.
+This rule applies regardless of which skill triggers the cancellation — `/issue` triage, `/pair` scope discovery, or manual operator action. If the operator cancels directly, suggest the comment.
 
 ### Filing mode: parse invocation
 
@@ -268,7 +268,7 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), a **DoD** sentence ("Done when X is true/observable/verifiable"), and the source-anchor backlink. The DoD should be concrete enough that someone can check it without reading the full context — e.g. "Done when `/linearissue` activates freeform mode on bare prompts and all titles pass the quality gate." Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), a **DoD** sentence ("Done when X is true/observable/verifiable"), and the source-anchor backlink. The DoD should be concrete enough that someone can check it without reading the full context — e.g. "Done when `/issue` activates freeform mode on bare prompts and all titles pass the quality gate." Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
 3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
@@ -278,7 +278,7 @@ After all `save_issue` calls succeed:
 
 5. **Re-read the note** (in case of any concurrent edits, though unlikely).
 6. **Append `Linear: LIN-NNN` cross-references.** For each newly-created ticket, find the source action item line in the note and append ` (Linear: [LIN-NNN]({url}))` immediately after the item text. For multi-line items, append on a new line indented to the item's level.
-7. **Append a Status Log row** to the note: today's date, `claude` as author, the comma-separated list of created/updated ticket IDs in the Related Tickets column, and a Notes column summary like "Filed N tickets via linearissue (M new, K updated)".
+7. **Append a Status Log row** to the note: today's date, `claude` as author, the comma-separated list of created/updated ticket IDs in the Related Tickets column, and a Notes column summary like "Filed N tickets via issue (M new, K updated)".
 8. **Save the note** via `Edit`.
 
 ### Partial failure
@@ -331,7 +331,7 @@ For mixed intents, address all of them in a single pass rather than asking for c
 
 Produce one or both of:
 
-1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. (Provenance and formatting are handled by the commenting skill — do not add `*[ai:claude-code]*` manually.)
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. (Provenance and formatting are handled by the comment skill — do not add `*[ai:claude-code]*` manually.)
 2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
 
 Print both drafts in chat before asking for confirmation. Make it easy to scan.
@@ -348,7 +348,7 @@ On "Edit first": ask what to change, revise, re-present, confirm again.
 
 On approval, write in this order:
 1. `save_issue` for any title/description changes (only if confirmed)
-2. `Skill("commenting", ...)` to delegate the comment to the commenting skill (only if confirmed) — describe the issue ID, comment title (e.g. "Assessment", "Context", "Scope refinement"), the originating skill name ("linearissue"), and the comment body. The commenting skill handles formatting, provenance, and threading.
+2. `Skill("comment", ...)` to delegate the comment to the comment skill (only if confirmed) — describe the issue ID, comment title (e.g. "Assessment", "Context", "Scope refinement"), the originating skill name ("issue"), and the comment body. The comment skill handles formatting, provenance, and threading.
 
 ### Summary
 
@@ -422,7 +422,7 @@ For each confirmed ticket, call `save_issue` with team, project, title, descript
 
 - Descriptions are minimal anchors (2–4 sentences max)
 - Prepend `*[ai:claude-code]*` to the description
-- If extra context is needed beyond the anchor, post it as a comment after creation via the commenting skill
+- If extra context is needed beyond the anchor, post it as a comment after creation via the comment skill
 
 ### Summary
 
@@ -450,7 +450,7 @@ Print:
 
 Every title — whether derived from a design note action item, drafted in freeform mode, or proposed as an iteration refinement — must pass through this gate. The gate is **advisory**: warn and suggest, never block.
 
-> **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is linearissue-specific) but the core principles and examples should match.
+> **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is issue-specific) but the core principles and examples should match.
 
 ### Pre-presentation checklist
 
@@ -510,7 +510,7 @@ This structure applies to ticket titles, PR subjects, and commit subjects — th
 - **Question-format titles** — "Does X expose Y?" belongs in the description.
 - **Kitchen-sink titles** — "Improve X — reduce Y and explore Z" tries to do too much in one title.
 - **Technical-identifier-first** — "bioguide_id mapping for member identity" buries the value. Prefer "Resolve member identity from bioguide".
-- **Redundant context** — "linearissue skill: value-oriented titles + freeform creation mode" — the project/component prefix is redundant when the ticket already has a project and labels.
+- **Redundant context** — "issue skill: value-oriented titles + freeform creation mode" — the project/component prefix is redundant when the ticket already has a project and labels.
 - **Context-dependent titles** — titles that only make sense if you were in the conversation that produced them. "Own protocol types at pipecat boundary" means nothing to a cold reader. "Codename alignment across codebase" sounds important but conveys no real value.
 
 ### Out-of-context failures (from audit)
@@ -561,7 +561,7 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 ## Anti-patterns
 
 - **Don't run on `decided`/`superseded`/`deprecated` records** or anything in `ARCHIVE/`. Settled records are read-only.
-- **Don't run on Linear documents.** This skill operates on repo-local `docs/decisions/**` files. Linear-routed records (from `designnote`'s strategy path) are not in scope.
+- **Don't run on Linear documents.** This skill operates on repo-local `docs/decisions/**` files. Linear-routed records (from `decision`'s strategy path) are not in scope.
 - **Don't transition frontmatter status.** Status transitions (`exploring → decided`) are HITL. Don't rename files either — serial-numbered filenames are permanent.
 - **Don't commit or stage.** All git operations are HITL per the repo's `CLAUDE.md`.
 - **Don't overwrite existing `Linear: LIN-NNN` annotations.** If present, the item is already ticketed; treat as update or skip, never re-create.
@@ -576,7 +576,7 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 - **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
 - **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
-- **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
+- **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `decision`.
 - **Don't cancel or duplicate tickets without commenting why.** Every state change that removes a ticket from the active backlog must carry a comment explaining the reason. A cancelled ticket with no explanation is a dead end for backlog reviewers. See the cancellation rule in Phase 0.
 - **Don't move issues across teams without setting team and project together.** Always set both in a single `save_issue` call to avoid transient inconsistency where the issue sits in a team that doesn't own the target project.
 
@@ -596,4 +596,4 @@ The skill's `allowed-tools` declaration pre-approves the tool categories. For sc
 
 The skill checks for this grant in Phase 0 and warns if it's missing.
 
-Linear MCP write tool (`save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("commenting", ...)`, which requires the `Skill` tool to be allowed so the commenting skill can be invoked.
+Linear MCP write tool (`save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("comment", ...)`, which requires the `Skill` tool to be allowed so the comment skill can be invoked.

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: pairprog
-description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
+name: pair
+description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pair', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pair`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use decision or direct implementation), for ticket creation (use issue), for research without implementation (use qsearch), or for commit message drafting (use commit)."
 api_description: "Pair-program on a Linear ticket: explore the codebase, assess unknowns, spike on feasibility, plan atomic steps, and implement with frequent HITL checkpoints. Posts assessments, spike findings, and progress back to the Linear ticket. Human commits each step; AI drives."
 allowed-tools: Bash Glob Grep Read Write Edit Task Skill AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
-# pairprog
+# pair
 
 Pair-program on a ticket. **You drive, the human navigates.**
 
@@ -25,16 +25,16 @@ The defining design principles are:
 >
 > **Comment everything back to the ticket.** Assessments, spike findings, plans, and step completions are posted as Linear comments. This means a cancelled session can be picked up later — the ticket carries the full context.
 
-**Commenting protocol.** All Linear comments are posted via the `commenting` skill (`Skill("commenting", ...)`). Pairprog describes what to comment; the commenting skill handles formatting, provenance, and threading. Store anchor comment IDs returned by the commenting skill to thread subsequent replies.
+**Commenting protocol.** All Linear comments are posted via the `comment` skill (`Skill("comment", ...)`). This skill describes what to comment; the comment skill handles formatting, provenance, and threading. Store anchor comment IDs returned by the comment skill to thread subsequent replies.
 
 ## Commit modes
 
 The skill supports two commit modes. The navigator can switch between them at any time during the session. A typical pattern on non-trivial work: start in checkpoint to refine the design through implementation, then switch to yolo once the remaining work is known and trivial.
 
-- **Checkpoint mode:** The skill presents each atomic change with a drafted commit message (using the `commitmsg` skill's methodology) and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
-- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill's methodology for message generation. The navigator can interrupt at any time to steer.
+- **Checkpoint mode:** The skill presents each atomic change with a drafted commit message (using the `commit` skill's methodology) and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
+- **Yolo mode:** The skill auto-commits each atomic step using the `commit` skill's methodology for message generation. The navigator can interrupt at any time to steer.
 
-**Commit messages are always drafted via `commitmsg` methodology** — reading `CONTRIBUTING.md` for the repo's convention and applying it. The modes differ in who *commits* (yolo: auto, checkpoint: navigator), not who *drafts the message*. Never draft commit messages freehand.
+**Commit messages are always drafted via `commit` methodology** — reading `CONTRIBUTING.md` for the repo's convention and applying it. The modes differ in who *commits* (yolo: auto, checkpoint: navigator), not who *drafts the message*. Never draft commit messages freehand.
 
 **Milestone file commit gate.** A `PostToolUse` hook monitors edits to milestone files (package manifests, lock files, flake.nix, etc.). When you see a `CHECKPOINT:` message from this hook, you **MUST** immediately:
 1. Stop implementation work
@@ -82,7 +82,7 @@ If the user passed a branch name directly rather than a ticket ID, check it out 
 Once the ticket ID is known and the branch is checked out, fetch all of these in parallel:
 
 - **Linear ticket:** `get_issue` with the ticket ID. Capture title, description, state, priority, labels, project, parent issue.
-- **Linear comments:** `list_comments` — read existing comments. If a previous pairprog session left assessment/plan/spike comments, note them. This is the resumption path.
+- **Linear comments:** `list_comments` — read existing comments. If a previous pair session left assessment/plan/spike comments, note them. This is the resumption path.
 - **Branch state:** `git log --oneline -10`, `git status`, `git diff main...HEAD` (or appropriate base branch) to understand what's already been done on this branch.
 - **Codebase orientation:** Use `Task` with `subagent_type: Explore` to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
 - **Repo conventions:** Read `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` at the repo root for development workflow, testing, and quality requirements.
@@ -117,7 +117,7 @@ After the branch is checked out and the ticket is loaded, call `save_issue` with
 
 ### Rename the session
 
-After the ticket is loaded, rename the session so the user can identify it at a glance (e.g. in a terminal tab or session list). A good name includes the ticket number and a 2–4 word summary — e.g. "VID-662 rename titles (pairprog)".
+After the ticket is loaded, rename the session so the user can identify it at a glance (e.g. in a terminal tab or session list). A good name includes the ticket number and a 2–4 word summary — e.g. "VID-662 rename titles (pair)".
 
 If a tool or command is available to rename the session programmatically, use it. Otherwise, suggest the user rename it themselves — but don't block on this. It's a nice-to-have, not a gate. Move on to the next phase either way.
 
@@ -136,13 +136,13 @@ Description:
 > [Quoted ticket description, trimmed to essentials]
 
 Prior session context (from comments):
-> [If previous pairprog comments exist, summarize what was assessed/planned/completed]
+> [If previous pair comments exist, summarize what was assessed/planned/completed]
 
 Branch work so far:
 > [Summary of existing commits on this branch, if any]
 ```
 
-If prior pairprog comments indicate the session was interrupted, note what was completed and what remains.
+If prior pair comments indicate the session was interrupted, note what was completed and what remains.
 
 ## Phase 1 — Assess and derisk
 
@@ -157,10 +157,10 @@ Read the ticket and existing branch work. Categorize what remains:
 
 ### Comment the assessment to Linear
 
-Post the assessment as an anchor comment via the commenting skill. Include the categorized unknowns (Clear and ready / Unclear / Feasibility unknowns / Blocked) as the body content:
+Post the assessment as an anchor comment via the comment skill. Include the categorized unknowns (Clear and ready / Unclear / Feasibility unknowns / Blocked) as the body content:
 
 ```
-Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Assessment\" from skill \"pairprog\" with body:
+Skill("comment", "Post an anchor comment on {ticket-id} titled \"Assessment\" from skill \"pair\" with body:
 
 **Clear and ready:**
 - Add Google OAuth callback endpoint
@@ -191,10 +191,10 @@ For each feasibility unknown, spawn a `Task` subagent to investigate:
 
 Subagents are read-only investigators. They don't write production code.
 
-**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings anchor per spike after the subagent returns, via the commenting skill:
+**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings anchor per spike after the subagent returns, via the comment skill:
 
 ```
-Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Spike: Google OAuth library compatibility\" from skill \"pairprog\" with body:
+Skill("comment", "Post an anchor comment on {ticket-id} titled \"Spike: Google OAuth library compatibility\" from skill \"pair\" with body:
 
 **Verdict:** Feasible ✓
 
@@ -308,10 +308,10 @@ Wait for the navigator's approval or adjustment before proceeding.
 
 ### Comment the plan to Linear
 
-After the navigator approves (or adjusts) the plan, post it as an anchor comment via the commenting skill:
+After the navigator approves (or adjusts) the plan, post it as an anchor comment via the comment skill:
 
 ```
-Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Plan\" from skill \"pairprog\" with body:
+Skill("comment", "Post an anchor comment on {ticket-id} titled \"Plan\" from skill \"pair\" with body:
 
 - [ ] Step 1: Add Google OAuth callback route
 - [ ] Step 2: Token storage in session metadata (parallel with 3)
@@ -330,10 +330,10 @@ For each step:
 1. **Announce** what you're about to do. "Starting Step 1 — adding the OAuth callback route."
 2. **Branch fit check.** Before touching any files, verify this step's files fit the branch purpose. Apply the Category A / Category B protocols from the Phase 0 branch fit check if a mismatch is detected.
 3. **Implement** the change. Use `Edit` / `Write` for code changes.
-4. **Decision record maintenance.** If the step touches a file in `docs/decisions/`, append a Status Log row: today's date, `claude` as author, the ticket ID in Related Tickets, and a concise note stating *what changed and why* — not just that an edit happened. Bake the purpose in so the row is scannable on its own (e.g. "Added disclosure-provider pricing comparison via pairprog KB-9", not a bare "Updated via pairprog KB-9"). This keeps the record's audit trail intact. If the step writes research or spike findings into the record (or any doc), apply the **Source-linking** rule from Phase 1 — every finding links inline to its source.
+4. **Decision record maintenance.** If the step touches a file in `docs/decisions/`, append a Status Log row: today's date, `claude` as author, the ticket ID in Related Tickets, and a concise note stating *what changed and why* — not just that an edit happened. Bake the purpose in so the row is scannable on its own (e.g. "Added disclosure-provider pricing comparison via pair KB-9", not a bare "Updated via pair KB-9"). This keeps the record's audit trail intact. If the step writes research or spike findings into the record (or any doc), apply the **Source-linking** rule from Phase 1 — every finding links inline to its source.
 5. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
 6. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
-7. **Draft commit message.** In both modes, use the `commitmsg` skill's methodology to draft the message: read `CONTRIBUTING.md` for the repo's convention (type, scope, subject rules, imperative mood, length limits), inspect the diff, and produce a conforming message. Never draft commit messages freehand — the convention is in the docs, not in your training data.
+7. **Draft commit message.** In both modes, use the `commit` skill's methodology to draft the message: read `CONTRIBUTING.md` for the repo's convention (type, scope, subject rules, imperative mood, length limits), inspect the diff, and produce a conforming message. Never draft commit messages freehand — the convention is in the docs, not in your training data.
 8. **Checkpoint.**
    - **Checkpoint mode:** Present the change summary and the drafted commit message. Pause for the navigator's steering input. If the navigator says "looks good," they commit using the drafted message. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
    - **Yolo mode:** Auto-commit with the drafted message. Print the commit hash and message. Continue to the next step.
@@ -342,10 +342,10 @@ For each step:
 
 ### Comment step completions to Linear
 
-After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a reply threaded under the plan anchor via the commenting skill:
+After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a reply threaded under the plan anchor via the comment skill:
 
 ```
-Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"Step 1 complete\" from skill \"pairprog\" with body:
+Skill("comment", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"Step 1 complete\" from skill \"pair\" with body:
 
 Added Google OAuth callback route in `src/routes/auth.ts` and `src/config/oauth.ts`.
 Test added in `src/routes/__tests__/auth.test.ts` — passing.
@@ -375,10 +375,10 @@ Pair programming is fluid. The plan from Phase 2 is a starting point, not a cont
 
 Accommodate without friction. The navigator steers.
 
-When mid-session adaptation happens, post the change as a reply to the plan anchor via the commenting skill. Use the appropriate emoji prefix in the title:
+When mid-session adaptation happens, post the change as a reply to the plan anchor via the comment skill. Use the appropriate emoji prefix in the title:
 
 ```
-Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"🚨 Plan adjusted\" from skill \"pairprog\" with body:
+Skill("comment", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"🚨 Plan adjusted\" from skill \"pair\" with body:
 
 Step 3 (Silent token refresh middleware) replaced with:
 Step 3a: Explicit re-login flow on token expiry
@@ -409,7 +409,7 @@ Print what was accomplished:
 
 If there are uncommitted changes (checkpoint mode only):
 
-- Use the `commitmsg` skill to generate messages for any uncommitted work
+- Use the `commit` skill to generate messages for any uncommitted work
 - If multiple logical changes are uncommitted, suggest breaking them into separate commits and provide a message for each
 - The navigator decides what to stage and commit
 
@@ -423,10 +423,10 @@ If the navigator says "not yet" or "more work needed," skip. The navigator will 
 
 ### Comment wrap-up to Linear
 
-Post a final session summary as a resolution reply to the plan anchor via the commenting skill:
+Post a final session summary as a resolution reply to the plan anchor via the comment skill:
 
 ```
-Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"✅ Session complete\" from skill \"pairprog\" with body:
+Skill("comment", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"✅ Session complete\" from skill \"pair\" with body:
 
 **Completed:**
 - [x] Step 1: OAuth callback route

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pairprog, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via the GitHub MCP on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
+description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pair, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via the GitHub MCP on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
 allowed-tools: Bash Glob Grep Read Agent AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__merge_pull_request mcp__github__update_pull_request mcp__github__search_repositories mcp__github__get_file_contents mcp__github__list_branches
 ---
 
@@ -144,7 +144,7 @@ The branch with the **fewest commits between its tip and HEAD** is the most like
 
 Evaluate the drafted title against these criteria. The gate is **advisory** — warn and suggest, never block.
 
-> **Sync note:** This gate is mirrored in `/linearissue` (`skills/linearissue/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold is 60 chars here vs 72 for tickets; no branch-name-friendliness principle here) but the core principles and examples should match.
+> **Sync note:** This gate is mirrored in `/issue` (`skills/issue/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold is 60 chars here vs 72 for tickets; no branch-name-friendliness principle here) but the core principles and examples should match.
 
 **Canonical structure:** PR subjects follow the same imperative voice as ticket titles and commit subjects: **`[VERB] [DIFFERENTIATING NOUN] [CONTEXT]`**. The `type(scope):` prefix categorizes the change — it doesn't replace the verb. The subject still needs an imperative verb that carries meaning.
 
@@ -292,7 +292,7 @@ The subagent should:
    - Report the failure: which check failed, link to the logs.
    - Fetch the failure details via `mcp__github__pull_request_read` and `Bash` with `gh run view <run-id> --log-failed` for actionable output.
    - Summarize what went wrong and suggest next steps (e.g. "lint failure in X — fixable here" or "test timeout — needs investigation").
-   - Ask the user how to proceed: fix it now (resume pairprog), investigate further, or leave it for later.
+   - Ask the user how to proceed: fix it now (resume pair), investigate further, or leave it for later.
 4. **On timeout (no checks appear within 2 minutes):**
    - Report: "No CI checks have started on PR #N. This repo may not have CI configured for this path, or checks are queued."
    - Do not suggest merging.


### PR DESCRIPTION
Surgical rename pass. Five skill directories renamed so the invocation matches the artifact or task, not the platform or grammar:

| Old | New |
|-----|-----|
| `commenting` | `comment` |
| `commitmsg` | `commit` |
| `designnote` | `decision` |
| `linearissue` | `issue` |
| `pairprog` | `pair` |

Each rename `git mv`s the skill dir, updates the `name:` frontmatter and `# heading`, and updates cross-references: `Skill("…")` call sites, `/`-invocation examples, prose mentions in other skills, and the `skills/README.md` table + symlink examples. Added a dated CHANGELOG migration entry. The deploy workflow derives each skill's Linear title from its directory name, so on next deploy the old skill entries are deleted and the new ones created.

Rename only — skill behavior and descriptions are otherwise unchanged. The gerund "commenting" (the activity, not the skill name) was preserved where it appears in skill bodies, and historical references in `CHANGELOG.md` and `docs/decisions/0002` were left intact (no history rewrite).

Deliberately deferred to existing issues:
- Description / routing-quality rewrites → KB-41
- Platform-language cleanup → KB-48
- Hardcoded path / portability refactors → KB-42
- Shared title quality-gate extraction & structural trimming → KB-44