### PR TITLE
feat(skills): broaden /commit to own full commit unit [KB-51]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,18 @@ Before opening a pull request, verify:
 - Reference documentation files when discussing changes
 - Keep the user informed of significant decisions or blockers
 
+## Skill Architecture Constraints
+
+**Skills must be self-contained.** Each skill (`skills/*/SKILL.md`) is a single file that carries all the instructions it needs. Skills must not reference companion files, shared docs, or other skills' content by file path — because not all deployment surfaces support multi-file skills:
+
+- **Claude Code (filesystem):** Skills are directories, but only `SKILL.md` is loaded as the prompt. Companion files work only if the skill reads them via tools at runtime.
+- **Claude Managed Agents (API):** Skills are passed as a single string parameter. There is no filesystem — companion files don't exist. Any shared content must be inlined (hydrated) into the skill string before dispatch.
+- **Linear AI:** Skills are plain text fields on team settings. No file references, no imports, no companion files.
+
+This means: if two skills need the same guidance (e.g., imperative-voice title conventions), each skill carries its own copy with a sync note pointing to the other. This is intentional duplication — the alternative (shared files) breaks portability. Sync notes are the maintenance mechanism: when you change a duplicated section, check the other copies listed in the sync note.
+
+The `/commit` skill is the authority on commit conventions (message drafting, type/scope selection, atomicity, staging, amend-vs-new). Other skills that produce commits (like `/pair`) delegate to `/commit` at invocation time rather than inlining the methodology. Title quality gates (verb tiers, imperative voice) are duplicated across `/commit`, `/pr`, and `/issue` with sync notes because each applies the same principles in a different context (commit subjects, PR titles, ticket titles).
+
 ## Claude-Specific Instructions
 
 - Challenge the user on ideas to collaboratively arrive at the best design. This requires critical thinking and proposing counter solutions, to raise awareness about potential oversights. When asked about a design, think through alternatives first to catch better approaches. **Do not be eager to agree with the user when there are solid arguments to push back.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,13 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 ## [2026-06-15]
 
 ### Changed
+- **`/commit` skill broadened to own full commit unit** — the skill now covers five areas beyond message drafting: type/scope selection guidance (canonical scopes from CONTRIBUTING.md, with missing-scope amendment suggestions), atomicity checks (multi-concern diff detection with concrete split plans), staging guidance (specific-file `git add` over blanket staging, mixed-state warnings), amend-vs-new commit decisions (default new, risk assessment when amend is requested), and convention health checks (escalate when CONTRIBUTING.md is missing, incomplete, or contains anti-patterns). Other skills (`/pair`, `/align`) should reference `/commit` as the authority on commit conventions — not just message text, but the full commit decision.
 - **Skills renamed to platform-agnostic imperative names** — five skill directories were renamed so the invocation matches the artifact or task, not the platform or grammar: `commenting` → `comment`, `commitmsg` → `commit`, `designnote` → `decision`, `linearissue` → `issue`, `pairprog` → `pair`. Cross-references between skills, `Skill("…")` call sites, `/`-invocation examples, and `skills/README.md` were updated to the new names. This is a rename only — skill behavior, descriptions, and bodies are otherwise unchanged.
 
 ### Migration
+
+**Files:**
+- If your project vendors a copy of `skills/commit/SKILL.md`, re-sync it to pick up the broadened scope (staging guidance, atomicity checks, type/scope selection, amend-vs-new decisions, convention health checks).
 
 **Files:**
 - If your project vendors copies of any renamed skill (`skills/commenting`, `skills/commitmsg`, `skills/designnote`, `skills/linearissue`, `skills/pairprog`), move them to the new directory names and update any internal `Skill("…")` references.

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,7 +7,7 @@ Claude Code skills that operate on KB-defined artifacts (decision records, TODO.
 | Skill | Purpose | KB artifacts touched |
 |-------|---------|---------------------|
 | **comment** | Post structured comments to Linear issues (threading, provenance, formatting) | None (protocol only) |
-| **commit** | Suggest commit messages following repo conventions | Reads CONTRIBUTING.md, AGENTS.md |
+| **commit** | Guide full commit unit: message drafting, type/scope selection, atomicity, staging, amend-vs-new | Reads CONTRIBUTING.md, AGENTS.md |
 | **decision** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
 | **issue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
 | **pair** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: commit
-description: "Use this skill when the user asks for a commit message suggestion based on their current uncommitted changes — or when the user invokes `/commit`. Trigger for prompts like 'suggest a commit message', 'commit', 'what should I commit this as', 'draft a commit', 'write a commit message for this'. The skill reads the repo's own docs (CONTRIBUTING.md, AGENTS.md, README.md) and the org knowledge base (via `./kb` or `./knowledge-base` symlink if present) for commit conventions, inspects the uncommitted diff and recent git history, and prints a suggested commit message in chat. It never commits, stages, or modifies files in normal mode. It also has a setup mode (`--setup`) that inspects git history, repo docs, and the org kb to draft or update the commit convention section in the repo's docs — run this once per repo to bootstrap the convention. Do NOT trigger for actually committing (the user runs git commit themselves), for amending or rebasing (those are direct git operations), for generating changelogs or release notes (different task), or for reviewing code (use a review skill or do it directly)."
-api_description: "Generate a commit message for the current staged diff, following the repo's documented conventions. Reads CONTRIBUTING.md, recent git history, and any org knowledge base for style. Never commits, stages, or modifies files."
+description: "Use this skill when the user asks for a commit message suggestion, staging advice, or guidance on how to structure a commit — or when the user invokes `/commit`. Trigger for prompts like 'suggest a commit message', 'commit', 'what should I commit this as', 'draft a commit', 'write a commit message for this', 'should I split this commit', 'what type/scope should I use', 'should I amend or make a new commit'. The skill owns the full commit unit: message drafting, type/scope selection, atomicity checks, staging guidance, and amend-vs-new decisions. It reads the repo's own docs (CONTRIBUTING.md, AGENTS.md, README.md) and the org knowledge base (via `./kb` or `./knowledge-base` symlink if present) for commit conventions, inspects the uncommitted diff and recent git history, and prints actionable guidance in chat. It never commits, stages, or modifies files in normal mode. It also has a setup mode (`--setup`) that inspects git history, repo docs, and the org kb to draft or update the commit convention section in the repo's docs — run this once per repo to bootstrap the convention. Do NOT trigger for actually committing (the user runs git commit themselves), for amending or rebasing (those are direct git operations), for generating changelogs or release notes (different task), or for reviewing code (use a review skill or do it directly)."
+api_description: "Guide the full commit unit: message drafting, type/scope selection, atomicity checks, staging advice, and amend-vs-new decisions — all following the repo's documented conventions. Reads CONTRIBUTING.md, recent git history, and any org knowledge base. Never commits, stages, or modifies files."
 allowed-tools: Bash Glob Grep Read Write Edit AskUserQuestion
 ---
 
 # commit
 
-Suggest a **commit message** for the user's current uncommitted changes, following the conventions documented in the repo itself.
+Guide the **full commit unit** — message drafting, type/scope selection, atomicity checks, staging advice, and amend-vs-new decisions — following the conventions documented in the repo itself.
 
 The defining design principles of this skill are:
 
-> **The repo's own docs are the source of truth for commit conventions.** The skill reads CONTRIBUTING.md, AGENTS.md, README.md — wherever the repo documents its convention. It does not hardcode any format.
+> **The repo's own docs are the source of truth for commit conventions.** The skill reads CONTRIBUTING.md, AGENTS.md, README.md — wherever the repo documents its convention. It does not hardcode any format. When CONTRIBUTING.md defines types and scopes, those are canonical — the skill enforces them rather than inventing alternatives.
 >
-> **Output only.** In normal mode, the skill prints a suggested commit message in chat and nothing else. No staging, no committing, no file writes. Git is HITL.
+> **Convention health matters.** If the repo's convention docs are missing, incomplete, or contain guidance that conflicts with best practices, the skill escalates to the operator rather than silently working around it. The goal is to improve the repo's conventions over time, not just comply with whatever exists.
+>
+> **The whole commit, not just the message.** The skill checks staging state, detects multi-concern diffs, advises on amend-vs-new, and guides type/scope selection — all before drafting the message. A good commit message on a bad commit is still a bad commit.
+>
+> **Output only.** In normal mode, the skill prints guidance and a suggested commit message in chat. No staging, no committing, no file writes. Git is HITL.
 >
 > **Setup bootstraps the convention into the repo's docs.** The `--setup` mode inspects git history, existing docs, and the org kb to draft the commit convention section. Run once per repo, then normal mode reads what setup wrote.
 
@@ -45,7 +49,18 @@ If none of these sources contain commit convention guidance, warn the user:
 
 Proceed with a plain descriptive message if the user doesn't want to set up.
 
-### Step 2 — Read the diff
+#### Convention health check
+
+After loading the convention, evaluate it for completeness and quality. Escalate to the operator when:
+
+- **CONTRIBUTING.md or AGENTS.md is missing entirely** — the repo has no documented commit convention. Suggest running `/commit --setup` to bootstrap one.
+- **Types or scopes are undocumented** — the convention exists but doesn't define which types/scopes are valid. Flag this: "Your CONTRIBUTING.md has a commit section but doesn't list valid types/scopes. Want me to add them based on git history?"
+- **Convention conflicts with best practices** — e.g., the docs say to use past tense ("added feature") when conventional commits use imperative ("add feature"), or the docs allow concatenated scopes. Flag the specific issue and suggest a fix rather than silently complying.
+- **Repo convention diverges from org kb** — if the org kb is available and its convention differs from the repo's, flag the divergence. The repo's convention wins (it's closer to the code), but the operator should know about the drift.
+
+The goal is to surface these issues once so the operator can fix them — not to nag on every invocation. If you flagged an issue and the operator said "leave it," respect that for the rest of the session.
+
+### Step 2 — Read the diff and check staging
 
 Run via `Bash`:
 
@@ -54,33 +69,112 @@ Run via `Bash`:
 - `git diff` — unstaged changes (flag these as not-yet-staged)
 - `git log --oneline -10` — recent commits for style continuity
 
-If nothing is staged, note this and base the suggestion on the full uncommitted diff (`git diff` + untracked). Mention that the user needs to stage before committing.
+#### Staging guidance
 
-### Step 3 — Draft the message
+Before analyzing the diff content, check the staging state and advise:
 
-Analyze the changes:
+- **Nothing staged at all:** Note this and base the suggestion on the full uncommitted diff (`git diff` + untracked). Tell the user what to stage: list the specific files with `git add <file1> <file2> ...` commands they can copy. Never suggest `git add .` or `git add -A` — these risk staging secrets (`.env`), build artifacts, or unrelated changes.
+- **Everything staged via `git add .`:** If the staged diff contains files that look unrelated to each other (e.g., a feature file and an unrelated config fix), flag it: "These staged changes look like they span multiple concerns. Consider unstaging with `git reset HEAD <file>` and committing in separate passes."
+- **Mix of staged and unstaged:** Call out which changes are staged (will be committed) and which aren't. If unstaged changes look like they belong with the staged ones, suggest adding them. If they look unrelated, note that they'll be left behind — which is correct.
+- **Untracked files:** If untracked files look related to the staged work (e.g., a new test file for a new module), suggest staging them. If they look unrelated, ignore them.
+
+### Step 3 — Analyze and check atomicity
+
+Analyze the changes (staged, or full diff if nothing staged):
 
 - **What changed:** files touched, nature of the changes (new feature, bug fix, refactor, docs, chore, test, etc.)
 - **Why it changed:** infer from the diff context, variable names, comments, test names. If the "why" isn't clear from the diff alone, say so rather than fabricating intent.
-- **Scope:** if the convention uses scopes (e.g., `feat(auth):`), derive from the primary directory or module affected.
 
-Apply the convention found in Step 1 to format the message. If the convention specifies:
-- A prefix format (e.g., `feat:`, `fix:`) — use it
+#### Atomicity check
+
+Before drafting a message, check whether the changes belong in a single commit:
+
+- **Single concern:** All changes serve one logical purpose (a feature + its tests, a refactor across files, a config change + its docs). Proceed to draft one message.
+- **Multiple concerns detected:** The diff contains unrelated changes that should be separate commits. Signs:
+  - Files in different modules with no shared purpose
+  - A bug fix mixed with a feature addition
+  - A formatting/style change mixed with a logic change
+  - Dependency updates mixed with code changes
+
+  When detected, suggest splitting. Print a concrete plan:
+
+  ```
+  This diff spans multiple concerns. Suggested split:
+
+  Commit 1 — fix: correct null check in auth middleware
+    git add src/middleware/auth.ts src/middleware/__tests__/auth.test.ts
+
+  Commit 2 — chore(deps): bump express to 4.19
+    git add package.json package-lock.json
+  ```
+
+  Provide a draft message for each proposed commit. The user decides whether to split or commit as-is.
+
+- **Implementation + tests:** These belong together in one commit. A test file for the module being changed is part of the same concern, not a separate one.
+- **Code + docs for the same change:** These belong together. If a feature adds an env var and the README documents it, that's one commit.
+
+### Step 4 — Select type and scope
+
+Derive the type and scope from the diff, guided by the convention found in Step 1.
+
+#### Type selection
+
+Match the nature of the change to the convention's type list. When the type isn't obvious:
+
+- **feat vs fix:** Does the change add a new capability (feat) or correct existing broken behavior (fix)? If existing behavior works but is being improved, that's `feat` or `refactor`, not `fix`.
+- **refactor vs feat:** Does the change alter external behavior? If yes, `feat` (or `fix`). If the behavior is identical but the implementation changed, `refactor`.
+- **doc vs chore:** Pure documentation is `doc`. Build/CI/tooling config is `chore`. A docs update that accompanies a code change isn't a separate `doc` commit — it's part of the code commit.
+- **style vs refactor:** If only whitespace/formatting changed with zero logic difference, `style`. If the code structure changed (even if behavior didn't), `refactor`.
+
+#### Scope selection
+
+If the convention defines scopes (e.g., a table in CONTRIBUTING.md), those are canonical — use them:
+
+- Match the primary area of the change to the scope table.
+- If the change spans multiple scopes, pick the primary one. Never concatenate scopes.
+- If no scope fits, omit it rather than invent one.
+- **Missing scope:** If the change clearly belongs to an area that *should* have a scope but the convention doesn't list one, flag this to the operator: "This change affects `{area}` but CONTRIBUTING.md doesn't list a scope for it. Suggest adding `{proposed-scope}` to the scope table?" This is how the convention grows organically — the skill notices gaps and proposes amendments rather than silently inventing ad-hoc scopes.
+
+If the convention doesn't define scopes at all, derive from the primary directory or module. Note this to the user as an implicit scope.
+
+### Step 5 — Decide amend vs new commit
+
+Before drafting, check whether this should be a new commit or an amend:
+
+- **Default: new commit.** Every change gets its own commit. This is the safe default that preserves history and makes review easier.
+- **Amend only when explicitly instructed.** The skill never suggests `--amend` on its own. Amending rewrites history — on shared branches it requires force-pushing, which is destructive.
+- **If the user asks about amending:** Evaluate and advise:
+  - **Safe to amend:** The commit being amended is the tip of a local branch that hasn't been pushed. No one else has built on it. Inform the user: "Safe to amend — this commit hasn't been pushed yet."
+  - **Risky to amend:** The commit has been pushed or is not the tip. Warn: "This commit is already pushed. Amending will require `--force-with-lease` on the remote. Consider adding a new commit instead."
+  - **Never amend:** The commit is on `main`/`master` or a shared branch. Refuse: "Don't amend commits on shared branches. Add a new commit."
+
+### Step 6 — Draft the message
+
+Apply the convention found in Step 1 to format the message using the type and scope from Step 4.
+
+If the convention specifies:
+- A prefix format (e.g., `feat:`, `fix:`) — use the type from Step 4
+- A scope — use the scope from Step 4 (or omit if none fits)
 - A tag (e.g., `[ai:claude]`) — include it
-- A max length — respect it
+- A max length — respect it. Run the subject line self-check if the convention requires it.
 - A body/footer structure — follow it
 
-**Always** include a `Co-Authored-By` trailer, regardless of whether the repo convention specifies one. This is the git-native AI provenance signal and renders distinctly in forge UIs (GitHub, GitLab show it as a secondary author avatar):
+**Body:** Explain *why*, not *what*. The diff shows what changed. If the "why" isn't clear from the diff alone, say so: "The intent isn't clear from the diff — you may want to add context in the commit body."
+
+**AI co-authorship trailers:** Always include provenance trailers, regardless of whether the repo convention specifies them. If the convention documents a specific trailer format, use it. Otherwise, default to both the established and emerging standards:
 
 ```
-Co-Authored-By: Claude Code <noreply@anthropic.com>
+Co-authored-by: Claude Code <noreply@anthropic.com>
+Assisted-by: Claude:claude-opus-4-6
 ```
+
+`Co-authored-by` is the GitHub-native convention (renders as a secondary author avatar). `Assisted-by` is the emerging standard from the Linux kernel guidelines. Using both ensures nothing is lost as tooling catches up.
 
 Print the suggested message in a fenced code block so the user can copy it.
 
-If the changes span multiple unrelated concerns, suggest breaking into multiple commits and provide a message for each.
+If Step 3 recommended splitting, provide a message for each proposed commit.
 
-### Step 4 — Done
+### Step 7 — Done
 
 No further action. The user copies the message and runs `git commit` themselves.
 
@@ -127,8 +221,12 @@ Print the path written and suggest a commit message for the convention documenta
 ## Anti-patterns
 
 - **Don't hardcode a commit format.** The convention lives in the repo's docs. If there's no convention, say so — don't silently impose one.
-- **Don't commit or stage.** The skill outputs text. Git operations are HITL.
+- **Don't commit or stage.** The skill outputs text and guidance. Git operations are HITL.
 - **Don't modify files in normal mode.** Only `--setup` writes to the repo.
 - **Don't fabricate intent.** If the "why" behind a change isn't clear from the diff, say "the intent isn't clear from the diff — you may want to add context in the commit body" rather than guessing.
-- **Don't suggest amending previous commits.** That's a destructive operation the user decides on their own.
+- **Don't suggest `--amend` unprompted.** New commit is always the default. Only discuss amend when the user explicitly asks.
+- **Don't invent scopes.** If the convention defines scopes, those are canonical. If none fits, omit rather than invent. If a scope *should* exist, suggest adding it to CONTRIBUTING.md — don't use it ad-hoc.
+- **Don't suggest `git add .` or `git add -A`.** Always suggest specific files by name. Blanket staging risks secrets, artifacts, and unrelated changes.
+- **Don't silently comply with bad conventions.** If CONTRIBUTING.md says something that conflicts with best practices (past tense subjects, concatenated scopes), flag it to the operator. The goal is to improve the convention, not just follow it.
 - **Don't hardcode the kb path.** The org kb is discovered via `./kb` or `./knowledge-base` symlink, not via an absolute path. If the symlink isn't there, the kb isn't available — don't go hunting.
+- **Don't nag about convention issues.** Flag a convention problem once per session. If the operator acknowledges it and says "leave it," respect that.

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -450,7 +450,7 @@ Print:
 
 Every title — whether derived from a design note action item, drafted in freeform mode, or proposed as an iteration refinement — must pass through this gate. The gate is **advisory**: warn and suggest, never block.
 
-> **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is issue-specific) but the core principles and examples should match.
+> **Sync note:** This gate is mirrored in `/pr` (`skills/pr/SKILL.md`) and the verb-tier/imperative-voice principles are shared with `/commit` (`skills/commit/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copies and keep them at parity. Some differences are intentional (brevity threshold, branch-name-friendliness is issue-specific; `/commit` applies the same voice to commit subjects with ≤80 char limits) but the core principles and examples should match. Skills are self-contained (see CLAUDE.md "Skill Architecture Constraints") — each carries its own copy.
 
 ### Pre-presentation checklist
 

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -34,7 +34,7 @@ The skill supports two commit modes. The navigator can switch between them at an
 - **Checkpoint mode:** The skill presents each atomic change with a drafted commit message (using the `commit` skill's methodology) and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
 - **Yolo mode:** The skill auto-commits each atomic step using the `commit` skill's methodology for message generation. The navigator can interrupt at any time to steer.
 
-**Commit messages are always drafted via `commit` methodology** — reading `CONTRIBUTING.md` for the repo's convention and applying it. The modes differ in who *commits* (yolo: auto, checkpoint: navigator), not who *drafts the message*. Never draft commit messages freehand.
+**Commit messages are always drafted via the `/commit` skill.** Invoke it (or apply its methodology) for every commit message — never draft freehand. The `/commit` skill owns the full commit unit: convention lookup, staging checks, atomicity, type/scope selection, amend-vs-new, and message formatting. The modes differ in who *commits* (yolo: auto, checkpoint: navigator), not who *drafts the message*.
 
 **Milestone file commit gate.** A `PostToolUse` hook monitors edits to milestone files (package manifests, lock files, flake.nix, etc.). When you see a `CHECKPOINT:` message from this hook, you **MUST** immediately:
 1. Stop implementation work
@@ -333,7 +333,7 @@ For each step:
 4. **Decision record maintenance.** If the step touches a file in `docs/decisions/`, append a Status Log row: today's date, `claude` as author, the ticket ID in Related Tickets, and a concise note stating *what changed and why* — not just that an edit happened. Bake the purpose in so the row is scannable on its own (e.g. "Added disclosure-provider pricing comparison via pair KB-9", not a bare "Updated via pair KB-9"). This keeps the record's audit trail intact. If the step writes research or spike findings into the record (or any doc), apply the **Source-linking** rule from Phase 1 — every finding links inline to its source.
 5. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
 6. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
-7. **Draft commit message.** In both modes, use the `commit` skill's methodology to draft the message: read `CONTRIBUTING.md` for the repo's convention (type, scope, subject rules, imperative mood, length limits), inspect the diff, and produce a conforming message. Never draft commit messages freehand — the convention is in the docs, not in your training data.
+7. **Draft commit message.** In both modes, delegate to the `/commit` skill for message drafting. The `/commit` skill handles convention lookup, type/scope selection, atomicity checks, and message formatting. Never draft commit messages freehand.
 8. **Checkpoint.**
    - **Checkpoint mode:** Present the change summary and the drafted commit message. Pause for the navigator's steering input. If the navigator says "looks good," they commit using the drafted message. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
    - **Yolo mode:** Auto-commit with the drafted message. Print the commit hash and message. Continue to the next step.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -144,7 +144,7 @@ The branch with the **fewest commits between its tip and HEAD** is the most like
 
 Evaluate the drafted title against these criteria. The gate is **advisory** — warn and suggest, never block.
 
-> **Sync note:** This gate is mirrored in `/issue` (`skills/issue/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copy and keep them at parity. Some differences are intentional (brevity threshold is 60 chars here vs 72 for tickets; no branch-name-friendliness principle here) but the core principles and examples should match.
+> **Sync note:** This gate is mirrored in `/issue` (`skills/issue/SKILL.md`) and the verb-tier/imperative-voice principles are shared with `/commit` (`skills/commit/SKILL.md`). If you change principles, anti-patterns, or examples here, check the other copies and keep them at parity. Some differences are intentional (brevity threshold is 60 chars here vs 72 for tickets; no branch-name-friendliness principle here; `/commit` applies the same voice to commit subjects with ≤80 char limits) but the core principles and examples should match. Skills are self-contained (see CLAUDE.md "Skill Architecture Constraints") — each carries its own copy.
 
 **Canonical structure:** PR subjects follow the same imperative voice as ticket titles and commit subjects: **`[VERB] [DIFFERENTIATING NOUN] [CONTEXT]`**. The `type(scope):` prefix categorizes the change — it doesn't replace the verb. The subject still needs an imperative verb that carries meaning.
 


### PR DESCRIPTION
## Summary
- Broaden `/commit` skill from message-only drafting to owning the full commit
  unit: staging guidance, atomicity checks, type/scope selection, amend-vs-new
  decisions, and convention health checks
- Convention health check escalates when CONTRIBUTING.md is missing, incomplete,
  or contains anti-patterns; canonical scopes from CONTRIBUTING win, missing
  scopes trigger amendment suggestions
- Updated skills/README.md description and added CHANGELOG migration entry

## Test plan
- [ ] Invoke `/commit` in a repo with CONTRIBUTING.md — verify it surfaces
      type/scope tables and staging advice
- [ ] Invoke `/commit` on a multi-concern diff — verify it suggests splitting
- [ ] Invoke `/commit` in a repo without CONTRIBUTING.md — verify it escalates

Closes KB-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)