### PR TITLE
doc(skills): document deployment surfaces and discovery limits [KB-11]

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -11,6 +11,7 @@ Claude Code skills that operate on KB-defined artifacts (decision records, TODO.
 | **decision** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
 | **issue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
 | **pair** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |
+| **ping** | Probe skill for verifying skill discovery on deployment surfaces | None (returns a static token) |
 | **pr** | Create pull requests with smart base branch detection | Reads Linear tickets |
 
 ## Skills that stay in dotfiles
@@ -34,3 +35,22 @@ pr       -> <PATH_TO_KB_REPO>/skills/pr
 ```
 
 `mkOutOfStoreSymlink` in nix-darwin follows the symlink chain — no config changes needed.
+
+## Deployment surfaces
+
+Skills deploy to multiple surfaces, each with different discovery mechanisms:
+
+| Surface | Discovery path | Notes |
+|---------|---------------|-------|
+| **Claude Code** (local CLI) | `~/.claude/skills/` (symlinked from dotfiles) | Full skill support |
+| **GitHub Copilot CLI** (`gh copilot`) | `.github/skills/` in the repo | Works — skills are loaded and matched by description |
+| **GitHub Copilot cloud agent** | `.github/skills/` in the repo (default branch) | Used when Copilot opens PRs or runs tasks |
+| **GitHub Copilot web chat** (github.com UI panel) | — | **Does not load repo skills.** The chat panel has repo file access but does not inject `.github/skills/` into its context. |
+| **GitHub Copilot code review** | `.github/skills/` (review-focused names) | Skills with review-oriented directory names are auto-loaded |
+| **Linear AI** | Deployed via `linear-skill-deploy.yaml` workflow | Skills are plain text fields on team settings |
+
+### `.github/skills/` sync
+
+Skills are authored in `skills/` (the canonical source) and copied to `.github/skills/` for GitHub Copilot discovery. The copies must stay in sync — the `check-skill-sync.yaml` CI workflow fails PRs if they diverge.
+
+**Important:** `.github/skills/` must contain real files, not symlinks. GitHub's cloud agent does not follow symlinks.


### PR DESCRIPTION
## Summary

- Document which platforms load `.github/skills/` (CLI, cloud agent, code review) and which don't (web chat panel)
- Document the `.github/skills/` sync mechanism and symlink gotcha
- Add `ping` probe skill to the skills table

Validated by testing `gh copilot -p "ping"` (skill fires) vs GitHub web UI chat (skill ignored).

## Test plan

- [ ] Review `skills/README.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)