### PR TITLE
doc(decisions): adopt DESIGN.md spec for repo-local design guides [KB-61]

### DIFF
--- a/.github/workflows/linear-skill-check.yaml
+++ b/.github/workflows/linear-skill-check.yaml
@@ -4,13 +4,11 @@ on:
   pull_request:
     # opened: PR first created. synchronize: new commits pushed to PR branch.
     # Together = "run on creation and every subsequent push."
+    # No paths filter — this workflow must always run because branch protection
+    # requires the "Check Linear skill deployment plan" status. If the workflow
+    # doesn't trigger, the status is never reported and the PR can't merge.
+    # The internal skills-diff step short-circuits when skills/ is unchanged.
     types: [opened, synchronize]
-    paths:
-      - 'skills/**'
-      - '.github/skills/**'
-      - '.github/scripts/**'
-      - '.github/workflows/linear-skill-check.yaml'
-      - '.github/workflows/check-skill-sync.yaml'
 
 permissions:
   pull-requests: read

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -196,6 +196,42 @@ cp -r <path-to-kb>/templates/decisions ./docs/
 
 Refer to the main [Engineering Handbook (README.md)](./README.md) for the philosophy on when and how to use each of these documents.
 
+### 7. Design Guide Setup (Optional)
+
+If the project has a visual design component (UI, components, Figma integration), set up a `DESIGN.md` file. This follows the [DESIGN.md open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md).
+
+**Option A: Seed from an existing Figma file**
+
+If the project already has a Figma file with defined styles and variables, use the [Figma-to-DESIGN.md plugin](https://github.com/bergside/design-md-figma) to generate a starter file:
+
+1. Install the plugin in Figma
+2. Run it on your project file — it extracts local styles into DESIGN.md format
+3. Review and customize the generated file
+
+**Option B: Start from the KB template**
+
+```bash
+cp <path-to-kb>/templates/DESIGN.md ./DESIGN.md
+```
+
+Then fill in the project-specific sections (marked with `<!-- PROJECT-SPECIFIC -->` comments):
+
+- `## Brand & Style` — brand personality, target audience, ICP framing
+- `## Colors` — semantic color palette (update YAML frontmatter tokens too)
+- `## Typography` — type scale (update YAML frontmatter tokens too)
+- `## Components` — project-specific component token mappings
+- `## Do's and Don'ts` — project-specific guardrails
+
+**Validation**
+
+Use the [npm CLI](https://github.com/google-labs-code/design.md) to validate your file against the spec:
+
+```bash
+npx @google/design.md validate DESIGN.md
+```
+
+This checks YAML schema, WCAG contrast ratios, circular token references, and section ordering.
+
 ## Template Customization Guide
 
 ### 1. GUIDELINES.md Customization

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -206,7 +206,8 @@ If the project already has a Figma file with defined styles and variables, use t
 
 1. Install the plugin in Figma
 2. Run it on your project file — it extracts local styles into DESIGN.md format
-3. Review and customize the generated file
+3. Compare the generated file against the [KB template](./templates/DESIGN.md) — the Figma plugin typically covers colors, typography, and spacing tokens but may omit prose sections (Brand & Style rationale, Do's and Don'ts, component guidance). Fill in any missing sections from the template.
+4. Review and customize the generated file
 
 **Option B: Start from the KB template**
 

--- a/PROJECT_SETUP_GUIDE.md
+++ b/PROJECT_SETUP_GUIDE.md
@@ -228,7 +228,7 @@ Then fill in the project-specific sections (marked with `<!-- PROJECT-SPECIFIC -
 Use the [npm CLI](https://github.com/google-labs-code/design.md) to validate your file against the spec:
 
 ```bash
-npx @google/design.md validate DESIGN.md
+npx @google/design.md lint DESIGN.md
 ```
 
 This checks YAML schema, WCAG contrast ratios, circular token references, and section ordering.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ _Ordered by developer workflow relevance_
 - **decisions/** (`./docs/decisions/`) - Decision records (exploration through to decided)
   - MADR-style serial numbering (`nnnn-slug.md`), enriched frontmatter, status log
   - See [templates/decisions/README.md](./templates/decisions/README.md) for format details, naming conventions, and status vocabulary
+- **DESIGN.md** (`./DESIGN.md`) - Visual design specification _(conditional)_
+  - Follows the [DESIGN.md open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md)
+  - YAML frontmatter with machine-readable tokens; Markdown body with design rationale
+  - Can be seeded from Figma via the [Figma plugin](https://github.com/bergside/design-md-figma) or validated with the [npm CLI](https://github.com/google-labs-code/design.md)
 - **LINTING_FORMATTING.md** (`./docs/LINTING_FORMATTING.md`) - Code Quality Standards _(conditional)_
 - **AGENTS.md** (`./AGENTS.md`) - AI agent guidelines _(conditional)_
   - `CLAUDE.md` and `GEMINI.md` are symlinks to `AGENTS.md`
@@ -254,6 +258,7 @@ _Ordered by developer workflow relevance_
 - **Add as workflow demands**:
   - **TODO.md**: When you need a repo-specific scratchpad.
   - **decisions/**: When exploring designs or recording architectural choices.
+  - **DESIGN.md**: When the project has a visual design component (UI, components, Figma integration).
   - **LINTING_FORMATTING.md**: Only when team size or complexity demands a separate file.
   - **AI Guidance**: When using AI development tools (`AGENTS.md`).
 

--- a/docs/decisions/0003-design-guide-standards.md
+++ b/docs/decisions/0003-design-guide-standards.md
@@ -120,7 +120,7 @@ Specifically:
 
 2. **AGENTS.md** (the template, not the KB's own) references DESIGN.md as required reading when design work starts. It also points to Figma workflow guidance and the design onboarding path — described by function, not by tool-specific endpoint names, so the guidance works across different agent systems.
 
-3. **Figma workflow patterns** (edit the base component, variables-first, verify visually, friction log of Plugin API edge cases) live in a dedicated capability separate from DESIGN.md. This is semantically distinct: DESIGN.md = "what to design", the Figma capability = "how to work effectively in Figma."
+3. **Figma workflow patterns** (edit the base component, variables-first, verify visually, friction log of Plugin API edge cases) live in a dedicated skill (tracked as KB-62). This is semantically distinct: DESIGN.md = "what to design", the Figma conventions skill = "how to work effectively in Figma."
 
 4. **The KB template links to the canonical spec** at the top of the file rather than duplicating the spec's documentation. Projects can use the [Figma plugin](https://github.com/bergside/design-md-figma) to seed their DESIGN.md from existing Figma files, or use the [npm CLI](https://github.com/google-labs-code/design.md) to validate their file against the spec.
 
@@ -136,8 +136,8 @@ Specifically:
 **Negative:**
 
 - Our ICP framing must fit within the spec's Overview section — no dedicated section for it
-- Figma-specific guidance is split across two locations (general design principles in DESIGN.md, tool workflow in the Figma conventions capability)
-- Projects that don't use Figma still get a template that assumes the Figma ecosystem (plugin, variable export) — may need adaptation for other tools
+- Figma workflow patterns live outside DESIGN.md (in the Figma conventions skill, KB-62) — collaborators need to know both resources exist
+- Projects that don't use Figma still get a template whose onboarding path references the Figma ecosystem (plugin, variable export) — may need adaptation for other tools
 
 **Trade-offs accepted:**
 

--- a/docs/decisions/0003-design-guide-standards.md
+++ b/docs/decisions/0003-design-guide-standards.md
@@ -149,4 +149,4 @@ Specifically:
 - **Template existence:** `templates/DESIGN.md` exists in the KB with spec-compliant structure and `<!-- PROJECT-SPECIFIC -->` markers
 - **AGENTS.md reference:** `templates/AGENTS.md` includes a design-work section that references DESIGN.md
 - **Onboarding path:** KB README and/or PROJECT_SETUP_GUIDE.md documents how to set up DESIGN.md in a new project (spec link, Figma plugin, CLI validation)
-- **Spec-purity check:** DESIGN.md files should pass validation via the `@google/design.md` npm CLI — this can be added as a pre-commit hook or CI check per project
+- **Spec-purity check:** DESIGN.md files should pass linting via `npx @google/design.md lint` — this can be added as a pre-commit hook or CI check per project

--- a/docs/decisions/0003-design-guide-standards.md
+++ b/docs/decisions/0003-design-guide-standards.md
@@ -1,0 +1,152 @@
+---
+title: "Design Guide Standards for Repo-Local Guides"
+tags: [design, documentation, standards, templates]
+status: decided
+decision: "Adopt the DESIGN.md open spec for repo-local design guides; keep it spec-pure with tooling guidance in AGENTS.md and Figma workflow patterns in a dedicated skill."
+review_date: 2026-12-24
+related_to: []
+supersedes: ""
+---
+
+# Design Guide Standards for Repo-Local Guides
+
+## Status Log
+
+| Status | Date       | Author | Related Tickets                                                  | Notes                                            |
+| :----- | :--------- | :----- | :--------------------------------------------------------------- | :----------------------------------------------- |
+| DONE   | 2026-06-24 | claude | [KB-61](https://linear.app/asabina/issue/KB-61) | Survey completed, decisions finalized via pairing |
+
+## Context
+
+Our engineering projects need a consistent way to document design guidance — visual identity, color semantics, typography, layout principles, and component conventions — so that both human collaborators and AI agents can produce coherent UI without re-discovering conventions each session.
+
+Our first design guide (`ivos-trades/DESIGN_GUIDE.md`) accumulated organically from Figma pairing sessions. It's effective but:
+
+- Local-only (not committed to git) and project-specific
+- Deeply coupled to Figma Plugin API workarounds
+- Missing standard sections (accessibility, interaction states, motion, content strategy)
+- No template exists in the KB for other projects to follow
+
+The question: what should a well-structured in-repo design guide contain, and how should we standardize it across projects?
+
+## Exploration
+
+### Survey of existing standards
+
+We surveyed conventions for repo-local design documentation. Key findings:
+
+**The DESIGN.md open spec (Google Labs, April 2026)**
+
+Google released an [open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) for `DESIGN.md` files via the Stitch project. It defines a dual-layer format:
+
+- **YAML frontmatter** — machine-readable tokens (colors, typography scales, spacing, component mappings)
+- **Markdown body** — human-readable rationale organized in mandatory section order
+
+Prescribed sections: Overview/Brand → Colors → Typography → Layout → Elevation & Depth → Shapes → Components → Do's & Don'ts → Responsive Behavior. An optional Agent Prompt Guide section exists for tool-specific meta-instructions.
+
+The spec has an [npm CLI](https://github.com/google-labs-code/design.md) that validates files, checks WCAG contrast ratios, and exports to Tailwind/W3C DTCG format. A [Figma plugin](https://github.com/bergside/design-md-figma) generates DESIGN.md files from Figma local styles.
+
+The [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) collection has 73+ brand examples (Linear, Stripe, Vercel, Cal.com, etc.), indicating real adoption. The collection had a [12.6% fork rate](https://dev.to/wonderlab/one-open-source-project-a-day-no-36-awesome-design-md-making-design-specs-truly-readable-for-304d) vs ~8-9% for comparable "awesome" lists.
+
+**Other in-repo design guide examples**
+
+- [contribute-design/examples](https://github.com/contribute-design/examples) — pre-AI template for inviting designer contributions to open-source projects. Covers: overview, target audience, current visual state, tools, contribution workflow.
+- [UNICEF design-system](https://github.com/unicef/design-system/blob/master/design-guidelines.md) — institutional example with principles explicitly shaped by non-visual constraints (network conditions, user tech savviness).
+- [MetaBrainz design-system](https://github.com/metabrainz/design-system/blob/master/guidelines/design-guidelines.md) — React component library guidelines nested in a `guidelines/` directory alongside Storybook.
+- [GitLab Pajamas](https://design.gitlab.com/get-started/structure/) — comprehensive open-source design system with sections for brand, foundations (tokens, color, typography, spacing, iconography), components, patterns, data visualization, content, and accessibility.
+
+**Storybook-driven guides** complement (not replace) a repo-local file. Typical structure: intro → getting started → contribution guidelines → design tokens → changelog → components. [Storybook docs](https://storybook.js.org/blog/structuring-your-storybook/) recommend pairing with the Figma plugin for in-tool validation.
+
+### Alternatives considered
+
+**A: Custom `DESIGN_GUIDE.md` convention**
+
+Define our own file name and structure, drawing from survey findings but not following any external spec.
+
+- (+) Full control over section ordering and content
+- (+) Can include tool-specific sections (Figma workflow, Plugin API workarounds)
+- (−) No ecosystem compatibility — tooling, linters, generators won't recognize it
+- (−) Maintenance burden of our own spec vs leveraging a community standard
+
+**B: Adopt `DESIGN.md` spec as-is**
+
+Follow the spec exactly. Keep the file spec-pure. Put everything else (tooling, Figma workflow, opinionated patterns) in other files.
+
+- (+) Full ecosystem compatibility (CLI validation, Figma plugin generation, awesome-design-md examples as references)
+- (+) Zero spec maintenance — the community maintains the standard
+- (+) AI agents that understand DESIGN.md (growing number) can consume our files natively
+- (−) The spec doesn't cover ICP/persona framing, content strategy, or tool workflow
+- (−) Requires additional files/guidance for what the spec omits
+
+**C: Extend `DESIGN.md` with custom sections**
+
+Follow the spec for standard sections but add non-spec sections for our needs (ICP, Figma workflow, friction log).
+
+- (+) Single file covers everything
+- (−) Non-spec sections may break tooling that validates against the spec
+- (−) Ambiguity about section ordering (spec mandates order for its sections)
+- (−) Coupling design guidance with tool-specific workflow
+
+### Where do non-spec concerns live?
+
+The survey identified content our projects need that the DESIGN.md spec intentionally omits:
+
+| Concern | Why the spec omits it | Where it belongs |
+| :--- | :--- | :--- |
+| ICP/persona framing | The spec's `## Overview` covers "target audience" briefly | DESIGN.md `## Overview` section (spec-compliant, marked project-specific) |
+| Figma workflow conventions | Spec is tool-agnostic by design | Dedicated capability in agent instructions (e.g., a Figma conventions guide) |
+| Figma Plugin API workarounds | Tool-specific edge cases | Same dedicated capability — not in any design guide |
+| Design onboarding path | Operational, not design content | AGENTS.md + KB README/PROJECT_SETUP_GUIDE.md |
+| Agent-specific tool instructions | Varies by agent system | AGENTS.md (or equivalent per agent platform) |
+
+### Single file vs split (`DESIGN.md` + `PRODUCT.md`)
+
+We considered separating product context (ICP, engagement cadence, mental models) into a `PRODUCT.md`. This was rejected:
+
+- The DESIGN.md spec's `## Overview` section already accommodates brief audience/brand framing
+- AI agents generating UI need both visual tokens and product context — one file read vs two
+- No tooling recognizes `PRODUCT.md` — agents wouldn't know to look for it
+- Adding another file to the doc stack (README, AGENTS, CONTRIBUTING, GUIDELINES, CHANGELOG, TODO, DESIGN_NOTES, DECISIONS) increases onboarding friction without proportional benefit
+
+Deep product strategy (full personas, market positioning, engagement models) belongs in the project README or a dedicated product brief if the project needs one — not in the design guide.
+
+## Decision
+
+**Adopt the [DESIGN.md open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) (Alternative B) for repo-local design guides. Keep the file spec-pure. Route non-spec concerns to their proper homes.**
+
+Specifically:
+
+1. **`DESIGN.md`** follows the community standard naming and section structure. Project-specific sections (Overview, Colors, Typography, Components, Do's & Don'ts) are marked with HTML comments (`<!-- PROJECT-SPECIFIC -->`) in the KB template so agents and humans can identify what needs customization per project.
+
+2. **AGENTS.md** (the template, not the KB's own) references DESIGN.md as required reading when design work starts. It also points to Figma workflow guidance and the design onboarding path — described by function, not by tool-specific endpoint names, so the guidance works across different agent systems.
+
+3. **Figma workflow patterns** (edit the base component, variables-first, verify visually, friction log of Plugin API edge cases) live in a dedicated capability separate from DESIGN.md. This is semantically distinct: DESIGN.md = "what to design", the Figma capability = "how to work effectively in Figma."
+
+4. **The KB template links to the canonical spec** at the top of the file rather than duplicating the spec's documentation. Projects can use the [Figma plugin](https://github.com/bergside/design-md-figma) to seed their DESIGN.md from existing Figma files, or use the [npm CLI](https://github.com/google-labs-code/design.md) to validate their file against the spec.
+
+## Consequences
+
+**Positive:**
+
+- Ecosystem compatibility: CLI validation, Figma plugin generation, awesome-design-md examples as starting points
+- Zero spec maintenance burden — Google Labs and the community maintain the standard
+- Clean separation between design specification (DESIGN.md), tooling workflow (Figma conventions), and agent instructions (AGENTS.md)
+- AI agents with DESIGN.md awareness can consume our files natively
+
+**Negative:**
+
+- Our ICP framing must fit within the spec's Overview section — no dedicated section for it
+- Figma-specific guidance is split across two locations (general design principles in DESIGN.md, tool workflow in the Figma conventions capability)
+- Projects that don't use Figma still get a template that assumes the Figma ecosystem (plugin, variable export) — may need adaptation for other tools
+
+**Trade-offs accepted:**
+
+- Spec-purity over convenience: we accept that one file doesn't cover everything in exchange for ecosystem compatibility
+- Community standard over custom: we lose control of section ordering and structure in exchange for not maintaining our own spec
+
+## Confirmation
+
+- **Template existence:** `templates/DESIGN.md` exists in the KB with spec-compliant structure and `<!-- PROJECT-SPECIFIC -->` markers
+- **AGENTS.md reference:** `templates/AGENTS.md` includes a design-work section that references DESIGN.md
+- **Onboarding path:** KB README and/or PROJECT_SETUP_GUIDE.md documents how to set up DESIGN.md in a new project (spec link, Figma plugin, CLI validation)
+- **Spec-purity check:** DESIGN.md files should pass validation via the `@google/design.md` npm CLI — this can be added as a pre-commit hook or CI check per project

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -65,6 +65,17 @@ npm run lint --help && npm run test --help && npm run build --help
 - **ALWAYS use `git rm` for file removals and `git mv` for file renames** - never use plain `rm` or `mv` for tracked files
 - **HITL — Git is human-in-the-loop.** Never create commits, push branches, or open/merge PRs unless the user has explicitly asked you to do so. Default to checking with a human operator before work is locked into the record.
 
+## Design Work
+
+**Before starting or continuing any design work** (UI implementation, component creation, visual changes, Figma collaboration), read these resources:
+
+1. **`DESIGN.md`** — the project's visual design specification. Follows the [DESIGN.md open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md). Contains color tokens, typography scale, spacing system, component token mappings, and design rationale. The YAML frontmatter is machine-readable; the Markdown body explains the "why."
+2. **Figma workflow conventions** — if the project uses Figma, consult the team's Figma workflow guidance for patterns on variable architecture, component editing discipline (always edit the base component, not instances), and visual verification after changes.
+
+If `DESIGN.md` does not exist yet, consult the [KB template](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) and the project lead before creating one. A DESIGN.md can be seeded from an existing Figma file using the [Figma-to-DESIGN.md plugin](https://github.com/bergside/design-md-figma) or authored manually following the spec.
+
+Sections marked `<!-- PROJECT-SPECIFIC -->` must be authored per project (brand personality, color palette, ICP framing, component inventory). Sections marked `<!-- CROSS-PROJECT -->` carry reusable structure — customize values but keep the structure.
+
 ## Documentation Workflow
 
 > [!TIP]

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -76,6 +76,12 @@ If `DESIGN.md` does not exist yet, consult the [KB template](https://github.com/
 
 Sections marked `<!-- PROJECT-SPECIFIC -->` must be authored per project (brand personality, color palette, ICP framing, component inventory). Sections marked `<!-- CROSS-PROJECT -->` carry reusable structure — customize values but keep the structure.
 
+**Keeping DESIGN.md in sync:**
+
+- When making design decisions during implementation (choosing a color, adding a spacing value, introducing a new component pattern), check whether the decision is already captured in DESIGN.md. If not, flag it to the operator: "This introduces [a new color / spacing value / component pattern] not yet in DESIGN.md — should we codify it?"
+- When design files (Figma, code) conflict with what DESIGN.md documents (e.g., a component uses a color not in the palette, or spacing deviates from the scale), surface the conflict to the operator. Don't silently follow either source — the operator decides which is correct and whether DESIGN.md needs updating.
+- Quick decisions made under time pressure to unblock work should still be surfaced after the fact: "I used [value/pattern] to keep moving — this should be reviewed for inclusion in DESIGN.md."
+
 ## Documentation Workflow
 
 > [!TIP]

--- a/templates/DESIGN.md
+++ b/templates/DESIGN.md
@@ -268,6 +268,7 @@ structural patterns — not implementation details.]
 **Do:**
 
 - Verify both light and dark modes after every visual change
+- Test with varying data lengths (short names, long names, edge cases)
 - Use semantic color tokens — never hardcode hex values in components
 - Maintain consistent spacing rhythm using the defined scale
 

--- a/templates/DESIGN.md
+++ b/templates/DESIGN.md
@@ -2,7 +2,7 @@
 # DESIGN.md — follows the open spec at:
 # https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
 #
-# Validate with: npx @google/design.md validate DESIGN.md
+# Lint with: npx @google/design.md lint DESIGN.md
 # Generate from Figma: https://github.com/bergside/design-md-figma
 #
 # Sections marked <!-- PROJECT-SPECIFIC --> must be authored per project.

--- a/templates/DESIGN.md
+++ b/templates/DESIGN.md
@@ -9,6 +9,11 @@
 # Sections marked <!-- CROSS-PROJECT --> carry reusable guidance — customize
 # values but keep the structure.
 
+# NOTE: "Tokens" in this file refers to *design tokens* — named values for
+# colors, spacing, typography, and other visual properties. This is standard
+# design systems terminology (see https://tr.designtokens.org/format/), not
+# related to LLM/AI tokens.
+
 name: "Project Name"
 
 # <!-- PROJECT-SPECIFIC: replace with your project's color tokens -->
@@ -192,13 +197,18 @@ Semantic = directional indicator).
 
 ## Layout & Spacing
 
-Spacing follows an 8px base unit scale. Consistent spacing rhythm creates
-visual grouping; uneven spacing breaks perceived structure.
+Spacing follows a consistent base unit scale. Consistent spacing rhythm
+creates visual grouping; uneven spacing breaks perceived structure.
 
-- **Base unit:** 8px
-- **Micro adjustments:** 4px (for tight inline spacing)
-- **Section padding:** Use the `md` (24px) or `lg` (40px) tokens
-- **Row/item gaps:** Use `sm` (12px) or `base` (8px) tokens
+The spec supports `px`, `em`, and `rem` units for dimensions — choose based
+on your project's needs (px for fixed layouts, rem for responsive scaling).
+The values in the YAML frontmatter above are placeholders; adjust them to
+match your project's spacing system.
+
+- **Base unit:** [your base unit, e.g., 8px or 0.5rem]
+- **Micro adjustments:** [half the base unit, for tight inline spacing]
+- **Section padding:** Use the `md` or `lg` spacing tokens
+- **Row/item gaps:** Use `sm` or `base` spacing tokens
 
 Every element should align to at least one other element. Stray elements that
 don't share edges or baselines with neighbors look accidental.
@@ -230,8 +240,8 @@ Corner radii follow a semantic scale:
 ## Components
 
 [Document component-specific styling guidance here. Use sub-headings for
-component categories. Focus on token usage, interactive states, and structural
-patterns — not implementation details.]
+component categories. Focus on design token usage, interactive states, and
+structural patterns — not implementation details.]
 
 ### Buttons
 
@@ -258,7 +268,6 @@ patterns — not implementation details.]
 **Do:**
 
 - Verify both light and dark modes after every visual change
-- Test with varying data lengths (short names, long names, edge cases)
 - Use semantic color tokens — never hardcode hex values in components
 - Maintain consistent spacing rhythm using the defined scale
 

--- a/templates/DESIGN.md
+++ b/templates/DESIGN.md
@@ -1,0 +1,273 @@
+---
+# DESIGN.md — follows the open spec at:
+# https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+#
+# Validate with: npx @google/design.md validate DESIGN.md
+# Generate from Figma: https://github.com/bergside/design-md-figma
+#
+# Sections marked <!-- PROJECT-SPECIFIC --> must be authored per project.
+# Sections marked <!-- CROSS-PROJECT --> carry reusable guidance — customize
+# values but keep the structure.
+
+name: "Project Name"
+
+# <!-- PROJECT-SPECIFIC: replace with your project's color tokens -->
+# Use semantic role names, not raw color names (e.g., "primary" not "blue").
+# Follow Material Design 3 naming conventions for maximum tooling compatibility.
+# See: https://m3.material.io/styles/color/roles
+colors:
+  # --- Surface / Background ---
+  surface: "#ffffff"
+  on-surface: "#1a1a1a"
+  surface-container: "#f4f4f4"
+  surface-container-low: "#fafafa"
+
+  # --- Primary ---
+  primary: "#0066cc"
+  on-primary: "#ffffff"
+  primary-container: "#d6e4ff"
+  on-primary-container: "#001a40"
+
+  # --- Secondary ---
+  secondary: "#5c5c5c"
+  on-secondary: "#ffffff"
+  secondary-container: "#e0e0e0"
+  on-secondary-container: "#1a1a1a"
+
+  # --- Semantic ---
+  positive: "#16a34a"
+  on-positive: "#ffffff"
+  negative: "#dc2626"
+  on-negative: "#ffffff"
+  warning: "#d97706"
+  on-warning: "#ffffff"
+
+  # --- Outline / Borders ---
+  outline: "#cccccc"
+  outline-variant: "#e5e5e5"
+
+# <!-- PROJECT-SPECIFIC: replace with your project's type scale -->
+# Use semantic level names. Recommended hierarchy (adapt to your needs):
+#   display > headline > title > body > label > caption
+typography:
+  display:
+    fontFamily: "Inter"
+    fontSize: 44px
+    fontWeight: "800"
+    lineHeight: 52px
+    letterSpacing: -0.02em
+  headline-lg:
+    fontFamily: "Inter"
+    fontSize: 32px
+    fontWeight: "700"
+    lineHeight: 40px
+    letterSpacing: -0.01em
+  headline-md:
+    fontFamily: "Inter"
+    fontSize: 24px
+    fontWeight: "700"
+    lineHeight: 32px
+  title-lg:
+    fontFamily: "Inter"
+    fontSize: 20px
+    fontWeight: "600"
+    lineHeight: 28px
+  body-lg:
+    fontFamily: "Inter"
+    fontSize: 18px
+    fontWeight: "400"
+    lineHeight: 28px
+  body-md:
+    fontFamily: "Inter"
+    fontSize: 16px
+    fontWeight: "400"
+    lineHeight: 24px
+  label-md:
+    fontFamily: "Inter"
+    fontSize: 14px
+    fontWeight: "600"
+    lineHeight: 20px
+    letterSpacing: 0.01em
+  caption:
+    fontFamily: "Inter"
+    fontSize: 12px
+    fontWeight: "400"
+    lineHeight: 16px
+
+# <!-- CROSS-PROJECT: adjust values but keep the scale structure -->
+rounded:
+  sm: 0.25rem
+  DEFAULT: 0.5rem
+  md: 0.75rem
+  lg: 1rem
+  xl: 1.5rem
+  full: 9999px
+
+# <!-- CROSS-PROJECT: adjust values but keep the scale structure -->
+spacing:
+  base: 8px
+  xs: 4px
+  sm: 12px
+  md: 24px
+  lg: 40px
+  xl: 64px
+  gutter: 16px
+  margin: 24px
+
+# <!-- PROJECT-SPECIFIC: define your project's component token mappings -->
+# Reference tokens from the groups above using {group.token} syntax.
+# Model interactive states as separate entries (e.g., button-primary-hover).
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.md}"
+  card:
+    backgroundColor: "{colors.surface}"
+    rounded: "{rounded.xl}"
+    padding: "{spacing.md}"
+  input-field:
+    backgroundColor: "{colors.surface-container-low}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.DEFAULT}"
+    padding: "{spacing.sm}"
+---
+
+<!-- PROJECT-SPECIFIC: replace this entire section with your project's brand
+     personality, target audience, and emotional tone. Include a brief ICP
+     framing (2-3 sentences about who the product serves and their mental
+     model) to anchor design decisions. -->
+
+## Brand & Style
+
+[Project Name] is designed for [target audience]. The visual language is
+[describe the emotional tone: e.g., "clean and professional with moments of
+warmth" or "dense and data-rich with high information density"].
+
+**Design principles:**
+
+- [Principle 1 — e.g., "Scannable in 3 seconds: primary data → supporting context → action"]
+- [Principle 2 — e.g., "No color without a reason: every color carries semantic meaning"]
+- [Principle 3 — e.g., "Structural consistency: same layout skeleton across sibling views"]
+
+<!-- PROJECT-SPECIFIC -->
+
+## Colors
+
+The palette uses semantic role naming. Colors communicate meaning, not
+decoration:
+
+- **Primary** — brand identity, primary actions, key interactive elements
+- **Surface** — backgrounds and containers at different elevation levels
+- **Positive / Negative** — directional feedback (gain/loss, success/error)
+- **Outline** — borders and separators
+
+Use the fewest colors needed. Each color carries semantic meaning — decorative
+color adds noise.
+
+Both light and dark modes must convey the same information with the same
+hierarchy. Elements that work in one mode but disappear or clash in the other
+are bugs.
+
+<!-- PROJECT-SPECIFIC -->
+
+## Typography
+
+The type scale uses [number] levels. Hierarchy is established through size.
+Differentiation within a level is achieved through weight (Bold = primary data,
+Regular = supporting data) and color (Primary = main value, Secondary = label,
+Semantic = directional indicator).
+
+**Rules:**
+
+- Never introduce intermediate sizes outside the defined scale
+- Same-level items differentiate through weight and color, not size
+- All text nodes must reference a token — never hardcode size/weight
+- Components that serve the same role must use the same text style
+
+<!-- PROJECT-SPECIFIC -->
+
+## Layout & Spacing
+
+Spacing follows an 8px base unit scale. Consistent spacing rhythm creates
+visual grouping; uneven spacing breaks perceived structure.
+
+- **Base unit:** 8px
+- **Micro adjustments:** 4px (for tight inline spacing)
+- **Section padding:** Use the `md` (24px) or `lg` (40px) tokens
+- **Row/item gaps:** Use `sm` (12px) or `base` (8px) tokens
+
+Every element should align to at least one other element. Stray elements that
+don't share edges or baselines with neighbors look accidental.
+
+<!-- CROSS-PROJECT -->
+
+## Elevation & Depth
+
+[Describe how visual hierarchy is achieved in this project: shadows, tonal
+surface layers, borders, blur, or a combination. If the project uses a flat
+design with no elevation, state that explicitly.]
+
+<!-- PROJECT-SPECIFIC -->
+
+## Shapes
+
+Corner radii follow a semantic scale:
+
+- **sm** (0.25rem) — subtle rounding for inline elements, badges
+- **DEFAULT** (0.5rem) — standard interactive elements, inputs
+- **lg** (1rem) — buttons, prominent interactive elements
+- **xl** (1.5rem) — cards, containers
+- **full** (9999px) — pills, avatars, circular elements
+
+[Adjust the scale and mapping to match your project's visual language.]
+
+<!-- CROSS-PROJECT -->
+
+## Components
+
+[Document component-specific styling guidance here. Use sub-headings for
+component categories. Focus on token usage, interactive states, and structural
+patterns — not implementation details.]
+
+### Buttons
+
+- Primary action is the most visually distinct element after the title
+- Use consistent styling for the primary CTA across all views
+
+### Cards
+
+- Cards of the same type share a structural skeleton: same layout, same column
+  positions, same component vocabulary
+- A user who has seen one card should instantly understand another
+
+### Data display
+
+- Visual encodings (bar widths, chart heights) must accurately reflect data
+  proportions
+- When data does not fit, show what fits plus a truncation indicator — never
+  clip content silently
+
+<!-- PROJECT-SPECIFIC -->
+
+## Do's and Don'ts
+
+**Do:**
+
+- Verify both light and dark modes after every visual change
+- Test with varying data lengths (short names, long names, edge cases)
+- Use semantic color tokens — never hardcode hex values in components
+- Maintain consistent spacing rhythm using the defined scale
+
+**Don't:**
+
+- Add color without semantic meaning — decorative color is noise
+- Mix hierarchy levels — if two elements look the same size but serve different
+  roles, one is at the wrong level
+- Silently clip content — always indicate when there is more to show
+- Introduce spacing values outside the defined scale
+
+<!-- PROJECT-SPECIFIC -->


### PR DESCRIPTION
## Summary

- Survey existing standards for repo-local design guides (DESIGN.md spec, awesome-design-md, GitLab Pajamas, UNICEF, MetaBrainz, contribute-design)
- Document decision to adopt Google's DESIGN.md open spec — keep the file spec-pure, route Figma workflow to a dedicated skill, route agent instructions to AGENTS.md
- Define project-specific vs KB-scoped boundary for design guide content
- Add spec-compliant `templates/DESIGN.md` with PROJECT-SPECIFIC/CROSS-PROJECT markers
- Update AGENTS.md template, README, and PROJECT_SETUP_GUIDE.md to reference DESIGN.md
- Filed KB-62 for Figma conventions skill extraction

## Test plan

- [x] Decision record follows template format (frontmatter, status log, all sections)
- [x] `templates/DESIGN.md` sections follow spec-prescribed order
- [ ] Links in decision record and AGENTS.md resolve to real pages
- [x] PROJECT_SETUP_GUIDE.md setup steps are actionable

Closes KB-61

🤖 Generated with [Claude Code](https://claude.com/claude-code)