### PR TITLE
chore(ci): add DESIGN.md spec lint workflow template [KB-63]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,15 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 
 ---
 
-## [2026-06-24]
+## [2026-06-25]
 
 ### Added
-- **DESIGN.md spec linting in CI template** — `templates/github-workflow-ci.yml` now includes a conditional step that lints `DESIGN.md` against the [open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) via `npx @google/design.md lint`. The step only runs when `DESIGN.md` exists in the repo root. Runs in advisory mode (`continue-on-error: true`) during initial adoption — tighten to strict once projects are spec-compliant.
+- **`templates/github-workflow-design.yml`** — standalone CI workflow that lints `DESIGN.md` against the [open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) via `npx @google/design.md lint`. Triggers only on `DESIGN.md` changes (`paths: [DESIGN.md]`). Advisory by default (`continue-on-error: true`) — tighten to strict once the project's file is fully spec-compliant.
 
 ### Migration
 
 **CI/CD:**
-- If your project copies `templates/github-workflow-ci.yml` as its CI workflow, re-sync to pick up the new DESIGN.md lint step. No action needed if you don't have a `DESIGN.md` file — the step auto-skips.
+- Copy `templates/github-workflow-design.yml` to `.github/workflows/design.yml` in projects that have a `DESIGN.md`. The workflow only triggers when `DESIGN.md` changes, so it adds no overhead to projects without one.
 
 ## [2026-06-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 
 ---
 
+## [2026-06-24]
+
+### Added
+- **DESIGN.md spec linting in CI template** — `templates/github-workflow-ci.yml` now includes a conditional step that lints `DESIGN.md` against the [open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) via `npx @google/design.md lint`. The step only runs when `DESIGN.md` exists in the repo root. Runs in advisory mode (`continue-on-error: true`) during initial adoption — tighten to strict once projects are spec-compliant.
+
+### Migration
+
+**CI/CD:**
+- If your project copies `templates/github-workflow-ci.yml` as its CI workflow, re-sync to pick up the new DESIGN.md lint step. No action needed if you don't have a `DESIGN.md` file — the step auto-skips.
+
 ## [2026-06-15]
 
 ### Changed

--- a/templates/github-workflow-ci.yml
+++ b/templates/github-workflow-ci.yml
@@ -36,12 +36,25 @@ jobs:
     name: Lint and Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       # Add your lightweight CI steps here:
       # - Linting
       # - Unit tests
       # - Code formatting checks
       # - Static analysis
-      - run: echo "Lightweight jobs always run"
+
+      # Lint DESIGN.md against the open spec when the file exists.
+      # Advisory only (continue-on-error) — tighten once projects are spec-compliant.
+      - name: Set up Node for DESIGN.md linter
+        if: hashFiles('DESIGN.md') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Lint DESIGN.md
+        if: hashFiles('DESIGN.md') != ''
+        continue-on-error: true
+        run: npx --yes @google/design.md lint DESIGN.md
 
   # Expensive jobs (skip on draft PRs)
   integration-tests:

--- a/templates/github-workflow-ci.yml
+++ b/templates/github-workflow-ci.yml
@@ -36,25 +36,12 @@ jobs:
     name: Lint and Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
       # Add your lightweight CI steps here:
       # - Linting
       # - Unit tests
       # - Code formatting checks
       # - Static analysis
-
-      # Lint DESIGN.md against the open spec when the file exists.
-      # Advisory only (continue-on-error) — tighten once projects are spec-compliant.
-      - name: Set up Node for DESIGN.md linter
-        if: hashFiles('DESIGN.md') != ''
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-      - name: Lint DESIGN.md
-        if: hashFiles('DESIGN.md') != ''
-        continue-on-error: true
-        run: npx --yes @google/design.md lint DESIGN.md
+      - run: echo "Lightweight jobs always run"
 
   # Expensive jobs (skip on draft PRs)
   integration-tests:

--- a/templates/github-workflow-design.yml
+++ b/templates/github-workflow-design.yml
@@ -1,0 +1,41 @@
+# DESIGN.md Spec Linting
+#
+# Validates DESIGN.md against the open spec when the file exists.
+# https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+#
+# Checks: YAML schema, WCAG contrast ratios, circular token references,
+# section ordering. Advisory by default (continue-on-error) — tighten
+# to strict once the project's DESIGN.md is fully spec-compliant.
+#
+# Other useful CLI commands (not used in CI, but handy locally):
+#   npx @google/design.md export css-tailwind DESIGN.md  — Tailwind v4 @theme
+#   npx @google/design.md export dtcg DESIGN.md          — W3C Design Tokens
+#   npx @google/design.md diff A.md B.md                  — token-level diff
+#   npx @google/design.md spec                            — print the spec
+
+name: Design
+
+on:
+  push:
+    branches: [main]
+    paths: [DESIGN.md]
+  pull_request:
+    branches: [main]
+    paths: [DESIGN.md]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-design:
+    name: Lint DESIGN.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Lint DESIGN.md
+        continue-on-error: true
+        run: npx --yes @google/design.md lint DESIGN.md


### PR DESCRIPTION
## Summary
- Add standalone `templates/github-workflow-design.yml` that lints `DESIGN.md` against the open spec via `npx @google/design.md lint`
- Uses `paths: [DESIGN.md]` filtering — only triggers when DESIGN.md changes
- Advisory mode (`continue-on-error: true`) — won't block PRs during initial adoption
- CHANGELOG entry added for downstream repo awareness

## Test plan
- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Confirm `templates/github-workflow-ci.yml` is reverted to its original state
- [ ] Copy workflow to a project with a `DESIGN.md` and verify it triggers on DESIGN.md changes

[KB-63](https://linear.app/asabina/issue/KB-63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)