### PR TITLE
doc(decisions): adopt DESIGN.md for corporate identity tokens [KB-68]

### DIFF
--- a/docs/decisions/0004-design-guide-corporate-identity.md
+++ b/docs/decisions/0004-design-guide-corporate-identity.md
@@ -1,0 +1,150 @@
+---
+title: "DESIGN.md Spec Coverage for Corporate Identity"
+tags: [design, corporate-identity, standards, brand]
+status: decided
+decision: "Use DESIGN.md for corporate identity visual tokens (colors, typography, spacing). Presentation design language encodes as component tokens. Watch the emerging brand.md standard for strategic brand context (voice, personality, positioning) but don't adopt it yet."
+review_date: 2026-12-25
+related_to: ["0003"]
+supersedes: ""
+---
+
+# DESIGN.md Spec Coverage for Corporate Identity
+
+## Status Log
+
+| Status | Date       | Author | Related Tickets                                                  | Notes                                                          |
+| :----- | :--------- | :----- | :--------------------------------------------------------------- | :------------------------------------------------------------- |
+| DONE   | 2026-06-25 | claude | [KB-68](https://linear.app/asabina/issue/KB-68) | Survey completed, decision finalized via pairing |
+
+## Context
+
+Decision record 0003 (KB-61) adopted the [DESIGN.md open spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) for repo-local design guides, scoped to app/UI design. During KB-66 (presentation template inventory), we found that presentation design language (dark backgrounds, section label styles, type hierarchy) needed a home. The question: can DESIGN.md also cover corporate identity — presentations, brand collateral, print — or does it need a separate spec?
+
+## Exploration
+
+### Can the DESIGN.md spec cover corporate identity?
+
+**Yes, with targeted extensions.** The spec is [intentionally format-agnostic](https://github.com/google-labs-code/design.md/blob/main/PHILOSOPHY.md) — "the format grows through its users, not its spec." The CLI's [section-order rule](https://github.com/google-labs-code/design.md/blob/main/packages/cli/src/linter/linter/rules/section-order.ts) ignores unknown sections entirely, so custom sections (`## Logo`, `## Slide Layouts`) pass through without error. The official [totality-festival example](https://github.com/google-labs-code/design.md/blob/main/examples/totality-festival/DESIGN.md) is a festival brand identity — not an app UI — confirming the maintainers consider the format usable beyond pure UI.
+
+**Section-by-section mapping:**
+
+| Corporate identity need | DESIGN.md coverage | Gap |
+| :--- | :--- | :--- |
+| Brand colors (screen) | Native — `colors` token | None |
+| Brand colors (CMYK print) | Custom key required | CMYK [rejected by color parser](https://github.com/google-labs-code/design.md/blob/main/packages/cli/src/linter/model/color-parser.ts) in `colors` block |
+| Presentation/print type scales | Works — `pt` and `mm` are [parseable dimensions](https://github.com/google-labs-code/design.md/blob/main/packages/cli/src/linter/model/spec.ts) | Semantic labels are screen-convention, not enforced |
+| Slide layout grids | Prose in `## Layout` section | No structured token for canvas dimensions |
+| Print bleed/margins | Custom section/key | No native token concept |
+| Logo usage rules | `## Do's and Don'ts` prose | No token-level enforcement |
+| Slide components (title, pricing table, quote card) | `components` token — custom properties accepted with warning | No slide-specific component vocabulary |
+| Brand guardrails | `## Do's and Don'ts` prose | Fully supported |
+
+### Structured brand identity frameworks ("brand as code")
+
+The field is nascent. Two notable projects exist:
+
+- [**brandspec**](https://github.com/brandspec/brandspec) (MIT, TypeScript) — YAML schema CLI with six sections: meta, core (essence, tagline, personality, voice), tokens (W3C DTCG format), assets (logo variants with print context flag), guidelines (severity levels), extensions. Outputs CSS, Tailwind v4, Figma tokens, Style Dictionary.
+- [**sentinels-identity**](https://github.com/sentinels-hub/sentinels-identity) (MIT, JS) — JSON Schema-validated brand system with YAML persona, voice/tone (formality scale, warmth scale, forbidden words), DTCG tokens, and AI agent personas. The most AI-native brand identity structure found.
+
+Both have minimal adoption (0-5 stars). No production-scale usage found.
+
+The [W3C Design Tokens Community Group (DTCG)](https://www.w3.org/community/design-tokens/) spec (stable October 2025) is explicitly digital-only: token types cover color (sRGB, Oklch, Display P3), dimension (px/rem), typography, duration, and composites. No CMYK, no slide dimensions, no brand voice.
+
+### The emerging `brand.md` standard
+
+Two independent initiatives propose a `brand.md` file:
+
+- [**caiopizzol/brand.md**](https://github.com/caiopizzol/brand.md) — "the AGENTS.md for brand context." Sections: Strategy (positioning, personality, promise), Voice (identity, tagline, tonal rules), Visual (colors, typography, photography).
+- [**Sameness-Design/brand.md**](https://github.com/Sameness-Design/brand.md) — three layers per element: Precision (machine-verifiable values), Semantic (mood keywords, image prompts), Relationship (governance rules, approved pairings). Explicitly positions brand.md as **upstream of design.md**: "Brand identity defines intent and constraints. Design systems execute those constraints."
+
+Neither has significant adoption yet. The conceptual split is sound: `brand.md` = "what is this brand and how does it think, speak, and look?" vs `design.md` = "how should this product interface be built?"
+
+### How companies handle it today
+
+Companies consistently **separate app design systems from corporate identity**, with weak token bridges:
+
+- [**GitHub (Primer)**](https://github.com/primer/brand) — two systems: Primer Product UI (app) and Primer Brand (marketing). Shared foundations (Mona Sans, GitHub Green), separate npm packages and governance.
+- [**Aerolab/brand-kauffman-fellows**](https://github.com/Aerolab/brand-kauffman-fellows) — token-first brand system (CSS, JSON, DTCG) consumable by Claude Design and web projects. Digital-only output targets.
+- **Large enterprises** (IBM, Microsoft, Atlassian) — separate brand identity and product design system teams. Token sync via manual governance, not tooling.
+
+No tool found explicitly generates presentation templates from design tokens. [Figma Slides](https://developers.figma.com/docs/plugins/working-in-slides/) sharing the same library/variable system as Figma Design is the closest approximation.
+
+### Alternatives considered
+
+**A: Single DESIGN.md for both app and corporate identity**
+
+One file covering UI components and slide/collateral design language.
+
+- (+) Single source of truth for all visual tokens
+- (+) Shared color palette and typography tokens naturally stay in sync
+- (−) File becomes large and confusing — app developers don't need slide component specs
+- (−) Different update cadences — app design changes frequently, brand identity rarely
+
+**B: Separate DESIGN.md files per context**
+
+`DESIGN.md` for app UI, a second file (e.g., `DESIGN.slides.md` or `BRAND_DESIGN.md`) for presentation/corporate identity.
+
+- (+) Clean separation of concerns — each file serves its audience
+- (+) Shared token foundations referenced via the same palette/type scale
+- (−) Risk of token drift between files
+- (−) No ecosystem support for multiple DESIGN.md files — tooling expects one
+
+**C: DESIGN.md for visual tokens + brand.md for strategic brand context**
+
+Use DESIGN.md (possibly per-context) for colors, typography, spacing, components. Adopt the emerging `brand.md` pattern for brand voice, personality, positioning.
+
+- (+) Matches the conceptual split the `brand.md` initiatives propose
+- (+) DESIGN.md stays spec-pure for visual/implementation concerns
+- (+) brand.md covers what DESIGN.md can't: voice, personality, strategic positioning
+- (−) brand.md is too nascent to adopt as a standard — 0-5 stars, no production usage
+- (−) Another file in the stack
+
+**D: Wait for the ecosystem to mature**
+
+Don't adopt anything beyond DESIGN.md for now. Revisit when brand.md or similar has real adoption.
+
+- (+) No premature commitment
+- (−) Corporate identity design language has no home in the meantime
+
+## Decision
+
+**Use DESIGN.md for corporate identity visual tokens. Watch brand.md but don't adopt yet. (Hybrid of A and D.)**
+
+Specifically:
+
+1. **One DESIGN.md per project** covers both app UI and presentation visual tokens. The spec's extensibility handles this — slide components model as `components` tokens (`title-slide`, `pricing-table`, `quote-card`), presentation typography as additional entries in the `typography` token group, and corporate color semantics alongside app color semantics in the `colors` group. The `## Do's and Don'ts` section carries brand usage rules (logo clear space, forbidden combinations).
+
+2. **Presentation-specific design language** (section label styles, page numbering conventions, slide dimensions) encodes in the DESIGN.md `## Components` section prose and as `components` tokens in the YAML frontmatter. This is the same pattern as app components — just different component names.
+
+3. **CMYK print colors** go in a custom `cmyk_colors` YAML key (the standard `colors` key rejects CMYK). The CLI accepts unknown top-level keys without error.
+
+4. **Don't adopt brand.md yet.** The concept is sound (brand identity upstream of design system), but the standard is too nascent (two competing specs, 0-5 stars each, no production usage). Revisit at the review date (2026-12-25) when the ecosystem has had 6 months to settle. If a project needs brand voice/personality documentation before then, use a custom `## Brand Voice` section in DESIGN.md or a freeform Markdown file — don't force a premature standard.
+
+5. **For the KB presentation template** (KB-66/KB-67): the design language removed from the inventory document should be encoded in the Figma Slides file's own DESIGN.md once the file has one. That DESIGN.md would carry the presentation color tokens, typography scale, and slide component definitions.
+
+## Consequences
+
+**Positive:**
+
+- One file covers both contexts — no token drift between separate files
+- DESIGN.md remains the single design reference agents read before any design work
+- Presentation components are first-class citizens alongside UI components
+- No premature commitment to a nascent standard
+
+**Negative:**
+
+- DESIGN.md files will be longer in projects that have both app UI and presentations
+- The brand voice/personality gap has no structured home until brand.md matures
+- CMYK requires a non-standard YAML key — tooling won't validate those values
+
+**Trade-offs accepted:**
+
+- Longer files over separate files: a single source of truth is worth the extra scrolling
+- No brand voice standard: prose in Do's and Don'ts or a freeform section is sufficient for now
+
+## Confirmation
+
+- Projects with both app and presentation design should have one DESIGN.md with both app and slide component tokens
+- Presentation design language from the KB-66 inventory is encoded as DESIGN.md component tokens, not in the inventory doc
+- CMYK values use a custom `cmyk_colors` YAML key, not the standard `colors` key
+- Review brand.md ecosystem maturity at 2026-12-25

--- a/docs/presentation-template-inventory.md
+++ b/docs/presentation-template-inventory.md
@@ -2,17 +2,7 @@
 
 Slide types for reusable pitch deck templates. Each type is a componentized master slide in Figma Slides with placeholder content (no client names). The inventory drives KB-67 implementation.
 
-## Design language
-
-- Dark background (near-black), white/gray text
-- Section labels in spaced uppercase monospace (`02 :: SECTION NAME`)
-- Page numbers as `NN / total` bottom-right
-- Company name bottom-left on applicable slides
-- Consistent type hierarchy: bold heading, regular body, monospace labels
-
 ## Slide type inventory
-
-### First implementation
 
 | # | Type | Layout | When to use |
 |---|---|---|---|
@@ -30,11 +20,6 @@ Slide types for reusable pitch deck templates. Each type is a componentized mast
 | 12 | **Quote / Testimonial** | Large pull-quote + attribution (name, role, org) | Social proof, client voice, stakeholder endorsement. |
 | 13 | **Metrics Highlight** | 2–3 large numbers with labels + optional context line | Impact stats, KPIs, before/after metrics — any "numbers that matter" message. |
 | 14 | **Full-Bleed Image** | Full-frame image with optional overlay text | Visual break, section divider, mood setter. |
-
-### Deferred (inventoried, not yet implemented)
-
-| # | Type | Layout | When to use |
-|---|---|---|---|
 | 15 | **Team / People** | Headshots + names + roles + brief bios | Emotional connector. Who the client will work with. |
 | 16 | **Comparison Matrix** | Feature/candidate grid with check/cross/rating marks | Tool evaluations, vendor comparisons, option scoring. |
 | 17 | **Case Study** | Problem → approach → result (3-panel or stacked) | Past work proof. Concrete example of delivered value. |
@@ -45,7 +30,7 @@ Slide types for reusable pitch deck templates. Each type is a componentized mast
 
 ### Typical engagement proposal arc
 
-Based on the Junction pitch deck structure:
+Based on an existing engagement proposal structure:
 
 1. **Cover** — who, what, when
 2. **Three-Column Points** — what we heard (empathy, mirror their pain)
@@ -67,12 +52,11 @@ Optional inserts depending on context:
 
 - All interaction goes through `use_figma` Plugin API — `get_metadata` and `generate_figma_design` don't support Slides files
 - The `figma-use-slides` skill handles Slides-specific operations
-- Target file: https://www.figma.com/slides/xXJMUyCLRXHmNPfwooiqK7 (needs edit access for MCP)
 - Each slide type becomes a Figma component on a Components page
 - See `skills/figma-conventions/SKILL.md` for component organization patterns
 
 ## Source
 
 Inventory derived from analysis of:
-- Junction Growth Investors engagement proposal (10 slides, Claude Design export)
-- Common pitch deck patterns across consulting/advisory presentations
+- An existing engagement proposal (10 slides, Claude Design export)
+- Common pitch deck patterns across consulting, advisory, and contract engineering presentations

--- a/docs/presentation-template-inventory.md
+++ b/docs/presentation-template-inventory.md
@@ -1,0 +1,78 @@
+# Presentation Template Inventory
+
+Slide types for reusable pitch deck templates. Each type is a componentized master slide in Figma Slides with placeholder content (no client names). The inventory drives KB-67 implementation.
+
+## Design language
+
+- Dark background (near-black), white/gray text
+- Section labels in spaced uppercase monospace (`02 :: SECTION NAME`)
+- Page numbers as `NN / total` bottom-right
+- Company name bottom-left on applicable slides
+- Consistent type hierarchy: bold heading, regular body, monospace labels
+
+## Slide type inventory
+
+### First implementation
+
+| # | Type | Layout | When to use |
+|---|---|---|---|
+| 1 | **Cover** | Title + subtitle + FOR/BY/DATE metadata | Opening slide. Sets project name, tagline, parties, and date. |
+| 2 | **Agenda / TOC** | Numbered section list with optional progress indicator | Orientation slide for decks with 5+ sections. |
+| 3 | **Three-Column Points** | Section label + heading + 3 numbered items (title + body) | Pain points, key themes, feature highlights — any "3 things" message. |
+| 4 | **Before/After Diagram** | Heading + two-panel visual comparison with arrow | Current state vs future state. Tool landscape, architecture, workflow. |
+| 5 | **Phase Timeline** | Heading + N phases with dot-line connector | Engagement structure, project roadmap, sequential milestones. |
+| 6 | **Phase Detail** | Heading + badge + description + deliverable tables | Deep dive on a single phase. Two-column layout for dual deliverables. |
+| 7 | **Process Flow** | Heading + horizontal stage row (e.g., Scope → Build → Roll Out) + example row | Sprint anatomy, workflow stages, any linear process. |
+| 8 | **Four-Point Grid** | Heading + subtitle + 2×2 numbered items + tagline | Support tiers, feature categories, value pillars — any "4 things" message. |
+| 9 | **Pricing Table** | Heading + N-row table (phase/scope/investment) + summary callouts | Investment overview. Rows per offering, callout for entry price and full program. |
+| 10 | **Credibility Split** | Heading + two-panel cards with center connecting element + tagline | "Why us" — two complementary strengths with visual bridge. |
+| 11 | **CTA / Closer** | CTA heading with fill-in-the-blank + contact details + confidentiality footer | Final slide. Call to action, champion/lead contacts, legal note. |
+| 12 | **Quote / Testimonial** | Large pull-quote + attribution (name, role, org) | Social proof, client voice, stakeholder endorsement. |
+| 13 | **Metrics Highlight** | 2–3 large numbers with labels + optional context line | Impact stats, KPIs, before/after metrics — any "numbers that matter" message. |
+| 14 | **Full-Bleed Image** | Full-frame image with optional overlay text | Visual break, section divider, mood setter. |
+
+### Deferred (inventoried, not yet implemented)
+
+| # | Type | Layout | When to use |
+|---|---|---|---|
+| 15 | **Team / People** | Headshots + names + roles + brief bios | Emotional connector. Who the client will work with. |
+| 16 | **Comparison Matrix** | Feature/candidate grid with check/cross/rating marks | Tool evaluations, vendor comparisons, option scoring. |
+| 17 | **Case Study** | Problem → approach → result (3-panel or stacked) | Past work proof. Concrete example of delivered value. |
+
+## Narrative guidance
+
+> Placeholder for future development: guidance on how to structure a strong deck — which slides in which order, which are must-haves vs optional, narrative arc (hook → problem → vision → approach → proof → ask). This may evolve into a skill that helps compose decks from the template inventory.
+
+### Typical engagement proposal arc
+
+Based on the Junction pitch deck structure:
+
+1. **Cover** — who, what, when
+2. **Three-Column Points** — what we heard (empathy, mirror their pain)
+3. **Before/After Diagram** — the vision (what it could look like)
+4. **Phase Timeline** — how we get there (overview)
+5. **Phase Detail** × N — deep dive per phase (with deliverables)
+6. **Pricing Table** — investment (anchored to phases)
+7. **Credibility Split** — why us
+8. **CTA / Closer** — next step
+
+Optional inserts depending on context:
+- **Quote/Testimonial** after Credibility Split (if available)
+- **Metrics Highlight** after Phase Detail (if past results exist)
+- **Team/People** before or after Credibility Split
+- **Agenda/TOC** after Cover (for longer decks, 10+ slides)
+- **Full-Bleed Image** as section dividers between phases
+
+## Figma Slides implementation notes
+
+- All interaction goes through `use_figma` Plugin API — `get_metadata` and `generate_figma_design` don't support Slides files
+- The `figma-use-slides` skill handles Slides-specific operations
+- Target file: https://www.figma.com/slides/xXJMUyCLRXHmNPfwooiqK7 (needs edit access for MCP)
+- Each slide type becomes a Figma component on a Components page
+- See `skills/figma-conventions/SKILL.md` for component organization patterns
+
+## Source
+
+Inventory derived from analysis of:
+- Junction Growth Investors engagement proposal (10 slides, Claude Design export)
+- Common pitch deck patterns across consulting/advisory presentations


### PR DESCRIPTION
## Summary

- Survey whether the DESIGN.md open spec covers corporate identity (presentations, brand collateral, print) beyond app/UI design
- Finding: the spec is intentionally extensible — custom sections and YAML keys pass through the CLI without error; the official `totality-festival` example is a brand identity, not an app
- Decision: use one DESIGN.md per project for both app and corporate identity visual tokens; slide components encode as component tokens; CMYK uses a custom YAML key
- Watch the emerging `brand.md` standard for strategic brand context (voice, personality) but don't adopt yet — too nascent (0-5 stars, no production usage)

## Test plan

- [ ] Decision record follows template format (frontmatter, status log, all sections)
- [ ] Links to external sources resolve
- [ ] Recommendation is consistent with decision 0003 (DESIGN.md adoption)

Closes KB-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)