### PR TITLE
doc: add DESIGN.md and refine skill conventions [KB-66]

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,230 @@
+---
+# DESIGN.md — Asabina GmbH Corporate Identity
+# Follows the open spec at:
+# https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+#
+# Lint with: npx @google/design.md lint DESIGN.md
+#
+# This file covers the company's visual identity across all surfaces:
+# app UI, presentations, print collateral. See decision record
+# docs/decisions/0004-design-guide-corporate-identity.md for rationale.
+
+name: "Asabina"
+
+colors:
+  # --- Core ---
+  background-dark: "#000000"
+  background-light: "#ffffff"
+  surface-dark: "#141414"
+  surface-light: "#f5f5f5"
+
+  # --- Text ---
+  on-dark: "#ffffff"
+  on-light: "#121212"
+  muted-on-dark: "#8c8c8c"
+  muted-on-light: "#737373"
+  label-on-dark: "#666666"
+  label-on-light: "#8c8c8c"
+
+  # --- Accent ---
+  accent: "#ff5583"
+
+  # --- Semantic ---
+  positive: "#16a34a"
+  negative: "#dc2626"
+
+  # --- Outline ---
+  outline-dark: "#333333"
+  outline-light: "#e5e5e5"
+
+typography:
+  title:
+    fontFamily: "Inter"
+    fontSize: 96px
+    fontWeight: "800"
+    lineHeight: 120%
+    letterSpacing: -0.02em
+  headline-lg:
+    fontFamily: "Inter"
+    fontSize: 60px
+    fontWeight: "700"
+    lineHeight: 120%
+    letterSpacing: -0.022em
+  headline-md:
+    fontFamily: "Inter"
+    fontSize: 48px
+    fontWeight: "700"
+    lineHeight: 120%
+    letterSpacing: -0.02em
+  headline-sm:
+    fontFamily: "Inter"
+    fontSize: 36px
+    fontWeight: "700"
+    lineHeight: 132%
+    letterSpacing: -0.02em
+  body-lg:
+    fontFamily: "Inter"
+    fontSize: 36px
+    fontWeight: "400"
+    lineHeight: 140%
+    letterSpacing: -0.01em
+  body-md:
+    fontFamily: "Inter"
+    fontSize: 30px
+    fontWeight: "400"
+    lineHeight: 136%
+    letterSpacing: -0.01em
+  body-sm:
+    fontFamily: "Inter"
+    fontSize: 24px
+    fontWeight: "400"
+    lineHeight: 134%
+    letterSpacing: -0.005em
+  label:
+    fontFamily: "Inter"
+    fontSize: 20px
+    fontWeight: "400"
+    lineHeight: 140%
+    letterSpacing: 0.3em
+  note:
+    fontFamily: "Inter"
+    fontSize: 20px
+    fontWeight: "400"
+    lineHeight: 140%
+  disclaimer:
+    fontFamily: "Inter"
+    fontSize: 14px
+    fontWeight: "400"
+    lineHeight: 160%
+
+rounded:
+  sm: 2px
+  DEFAULT: 4px
+  lg: 8px
+
+spacing:
+  base: 8px
+  xs: 4px
+  sm: 16px
+  md: 24px
+  lg: 40px
+  xl: 60px
+  section: 120px
+
+components:
+  slide-cover:
+    backgroundColor: "{colors.background-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.title}"
+  slide-content:
+    backgroundColor: "{colors.background-dark}"
+    textColor: "{colors.on-dark}"
+    typography: "{typography.body-sm}"
+  slide-accent-line:
+    backgroundColor: "{colors.accent}"
+    height: 4px
+    rounded: "{rounded.sm}"
+---
+
+## Brand & Style
+
+Asabina is an engineering consultancy that helps companies become AI-native.
+The visual language is high-contrast, minimal, and information-dense — black
+backgrounds, white text, pink accents. The brand communicates technical
+credibility through restraint: no decorative elements, no gradients, no
+unnecessary chrome. Every visual element earns its place.
+
+**Design principles:**
+
+- High contrast first: black/white base, pink accent for emphasis
+- Information density over decoration: every element conveys meaning
+- Consistent restraint: minimal corner radii, no shadows, no gradients
+- Parametric: all values are variables, switchable between dark and light modes
+
+## Colors
+
+The palette is built around a black/white axis with a single accent color.
+
+- **Background** — pure black (`#000000`) for dark mode, pure white for light
+- **Accent** — pink `rgb(255, 85, 131)` / `#ff5583` — the only chromatic color
+  in the primary palette. Used for subtitles, secondary CTAs, and emphasis
+- **Text hierarchy** — white → gray → dim gray, three levels of prominence
+- **Semantic** — green for positive, red for negative (standard, not branded)
+
+Two modes exist: **Asabina Dark** (default, black background) and **Asabina
+Light** (white background). The accent pink stays constant across both modes.
+
+## Typography
+
+One typeface: **Inter**. Hierarchy through size and weight, never through
+typeface variation.
+
+The type scale maps to Figma Slides template styles: Title (96px), Header 1-3
+(60/48/36px), Body 1-3 (36/30/24px), Note (20px), Label (20px uppercase with
+letter-spacing), Disclaimer (14px).
+
+**Rules:**
+
+- `textCase = 'UPPER'` for labels and section markers — never hardcode
+  uppercase into the text content
+- `letterSpacing` for spaced-out label treatments — never add spaces between
+  characters
+- Same-level items differentiate through weight (Bold = primary, Regular =
+  supporting) and color (Primary = main value, Muted = secondary)
+
+## Layout & Spacing
+
+Presentation slides use a 1920x1080 canvas with 120px left/right margins.
+
+- **Three-column layout:** 520px columns, 60px gaps
+- **Section label** at y=80, heading at y=140, content starting at y=340
+- **Page number** bottom-right at (1740, 1030)
+- **Pink accent line** — 80-120px wide, 4px tall, positioned below the heading
+  as a signature element. Decorative, not margin-to-margin.
+
+## Elevation & Depth
+
+Flat design. No shadows, no elevation layers. Depth is communicated through
+color contrast (foreground elements are brighter on dark, darker on light) and
+thin divider lines (`#333333` on dark, `#e5e5e5` on light).
+
+## Shapes
+
+Minimal corner radii: 2px for small elements, 4px default, 8px for larger
+containers. No large radius treatments. No rounded pills except for badges.
+
+## Components
+
+Slide components follow the inventory in `docs/presentation-template-inventory.md`.
+The master deck is at [Asabina Master Deck](https://www.figma.com/slides/xXJMUyCLRXHmNPfwooiqK7).
+
+### Slides
+
+- Every slide has a section label (Label style, top-left), a heading
+  (H1 or Title, below the accent line), and a page number (Note, bottom-right)
+- The pink accent line appears on every slide as a signature element
+- Metadata uses "ORG @ **Person**" format with bold on the person name
+
+### Accent line
+
+A short (80-120px) pink rectangle, 4px tall, with 2px corner radius. Positioned
+below the section label, above the heading. This is the visual signature —
+present on every slide, recognizable out of context.
+
+## Do's and Don'ts
+
+**Do:**
+
+- Use `textCase` and `letterSpacing` for visual text transforms
+- Verify both Asabina Dark and Asabina Light modes after visual changes
+- Test with varying data lengths (short names, long names, edge cases)
+- Use Deck Theme variables for all colors — never hardcode hex values
+- Maintain consistent spacing rhythm using the defined scale
+
+**Don't:**
+
+- Add spaces between characters in text content — use `letterSpacing`
+- Type text in uppercase — use `textCase = 'UPPER'`
+- Add color without purpose — the only chromatic color is the accent pink
+- Use shadows, gradients, or decorative elements
+- Mix font families — Inter is the only typeface

--- a/docs/presentation-template-inventory.md
+++ b/docs/presentation-template-inventory.md
@@ -48,11 +48,17 @@ Optional inserts depending on context:
 - **Agenda/TOC** after Cover (for longer decks, 10+ slides)
 - **Full-Bleed Image** as section dividers between phases
 
-## Figma Slides implementation notes
+## Figma Slides template
 
+**Master deck:** [Asabina Master Deck](https://www.figma.com/slides/xXJMUyCLRXHmNPfwooiqK7)
+
+**Implementation notes:**
 - All interaction goes through `use_figma` Plugin API — `get_metadata` and `generate_figma_design` don't support Slides files
 - The `figma-use-slides` skill handles Slides-specific operations
-- Each slide type becomes a Figma component on a Components page
+- Per-slide dark/light theming via `setExplicitVariableModeForCollection` on the "Deck Theme" collection
+- "Deck Theme" variables: Background, Text/Primary, Text/Muted, Text/Label, Text/Accent, Font/Family
+- Two modes: "Asabina Dark" (black bg, white text) and "Asabina Light" (white bg, dark text)
+- Pink accent `rgb(255, 85, 131)` stays constant across both modes
 - See `skills/figma-conventions/SKILL.md` for component organization patterns
 
 ## Source

--- a/skills/figma-conventions/SKILL.md
+++ b/skills/figma-conventions/SKILL.md
@@ -194,6 +194,18 @@ Organize Figma files with clear page separation:
 
 Within the Components page, organize in horizontal columns left-to-right by category, with generous spacing (80px+) between items for isolation.
 
+### Semantic text content — style through properties, not content hacks
+
+Text node content should be the raw, unstyled value. All visual transformations — uppercase, letter spacing, underlines, strikethrough — are applied via styling properties, never baked into the text string.
+
+**Common violations:**
+- Adding spaces between characters for a spaced look (`"E N G A G E M E N T"`) — use `letterSpacing` instead
+- Typing text in all caps (`"ENGAGEMENT PROPOSAL"`) — use `textCase = 'UPPER'` instead
+- Adding underscores or dashes as placeholder lines — use a rectangle or stroke instead
+- Inserting bullets as text characters (`"• Item"`) — use `setRangeListOptions` for native list formatting
+
+**Why this matters:** content hacks make text uneditable and unsearchable. A user who changes the text to "Project Update" shouldn't have to manually re-space characters. Styling properties are parametric — they survive text edits and can be toggled without rewriting content.
+
 ## Don't pretend to see something you don't
 
 When verifying a change visually, if the screenshot shows the same state as before, say so. Don't construct a narrative about how it "actually looks correct" when it doesn't. The user can see the same image.

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -268,7 +268,14 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), a **DoD** sentence ("Done when X is true/observable/verifiable"), and the source-anchor backlink. The DoD should be concrete enough that someone can check it without reading the full context — e.g. "Done when `/issue` activates freeform mode on bare prompts and all titles pass the quality gate." Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences of context followed by a **"Done when:" checklist** — a markdown checkbox list where each item is a concrete, verifiable condition. Use checklist style (`- [ ] condition`) not prose style ("Done when X is true"). Checklist items can be checked off as they're completed, giving visibility into partial progress. Each item should be specific enough that someone can check it without reading the full context. Example:
+   ```
+   **Done when:**
+   - [ ] Export existing data as CSV
+   - [ ] Validate schema against spec
+   - [ ] Document migration steps in README
+   ```
+   Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
 3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
@@ -370,7 +377,7 @@ Read the user's prompt and extract:
 For each item, draft:
 
 - **Title** — derive from the user's description, then run the **title quality gate pre-presentation checklist**: imperative `[VERB] [NOUN] [CONTEXT]`, verb from tier list, cold-reader check. If the gate fires, present the original and suggested rewrite.
-- **Description** — 2–5 sentences maximum: what the work is, why it matters (if not obvious), and a **DoD** sentence ("Done when X is true/observable/verifiable"). Prepend `*[ai:claude-code]*` as the first line. Keep it minimal — the anchor principle applies just as in filing mode.
+- **Description** — 2–5 sentences of context followed by a **"Done when:" checklist** — markdown checkboxes (`- [ ] condition`) for each verifiable completion criterion. Prepend `*[ai:claude-code]*` as the first line. Keep it minimal — the anchor principle applies just as in filing mode.
 - **Priority** — infer from the user's language (urgent, blocker, nice-to-have, etc.). Default Normal.
 - **Labels** — infer from context (e.g. "bug" → Bug label, "research" → Research label). Only apply if confident.
 
@@ -571,7 +578,7 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 - **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
 - **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way. Crucially, don't model items as sub-issues when they're actually dependencies: if two items would be assigned to different people doing different work, they're flat peers with a `blocks`/`blockedBy` relation, not a parent/child decomposition. See **Phase 2 → Work breakdown** for the full rule.
 - **Don't over-fill descriptions.** A description is a minimal anchor — 2–5 sentences max (what, why, DoD, backlink). Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
-- **Don't skip the DoD.** Every ticket needs a "Done when..." sentence in the description. It should be concrete and verifiable — not "done when implemented" but "done when X is observable/testable." If the source material doesn't imply a clear DoD, draft one from the action item's intent and surface it in the confirmation gate for the user to refine.
+- **Don't skip the DoD.** Every ticket needs a "Done when:" checklist in the description — markdown checkboxes (`- [ ] condition`), not a prose sentence. Each item should be concrete and verifiable — not "done when implemented" but specific observable conditions. Checklist style enables partial-progress tracking (items can be checked off as completed). If the source material doesn't imply clear DoD items, draft them from the action item's intent and surface them in the confirmation gate for the user to refine.
 - **Don't default to description updates in iteration mode.** The user's intent is almost always to add a comment. Only propose a title/description change when the prompt explicitly targets the anchor (e.g. "the title is wrong", "rewrite the description"). When in doubt, put it in a comment.
 - **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
 - **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.


### PR DESCRIPTION
## Summary
- Add Asabina DESIGN.md with corporate identity tokens and link to Figma Slides template
- Add semantic text content convention to figma-conventions (style via properties, not content hacks)
- Switch issue skill to checklist-style Done-when definitions

## Test plan
- [ ] Verify DESIGN.md renders correctly on GitHub
- [ ] Verify figma-conventions and issue skill changes are additive and don't break existing content

https://linear.app/asabina/issue/KB-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)