### PR TITLE
doc(skills): enforce portable tool references across skills [KB-14]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ This means: if two skills need the same guidance (e.g., imperative-voice title c
 
 The `/commit` skill is the authority on commit conventions (message drafting, type/scope selection, atomicity, staging, amend-vs-new). Other skills that produce commits (like `/pair`) delegate to `/commit` at invocation time rather than inlining the methodology. Title quality gates (verb tiers, imperative voice) are duplicated across `/commit`, `/pr`, and `/issue` with sync notes because each applies the same principles in a different context (commit subjects, PR titles, ticket titles).
 
+**When authoring or modifying skills**, follow the portability guidelines in [`skills/README.md`](./skills/README.md) — they define how to write tool references that work across Claude Code, OpenCode, GitHub Copilot, and middleware like Composio.
+
 ## Claude-Specific Instructions
 
 - Challenge the user on ideas to collaboratively arrive at the best design. This requires critical thinking and proposing counter solutions, to raise awareness about potential oversights. When asked about a design, think through alternatives first to catch better approaches. **Do not be eager to agree with the user when there are solid arguments to push back.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Both trailers survive squash-merge in the commit body.
 | Scope | Covers |
 |---|---|
 | `templates` | Template files in `templates/` |
-| `skills` | Skill definitions in `skills/` |
+| `skills` | Skill definitions in `skills/` — see [`skills/README.md`](./skills/README.md) for authoring and portability guidelines |
 | `decisions` | Decision records in `docs/decisions/` |
 | `ci` | CI/CD pipeline configuration |
 | `deps` | Dependency updates |

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,6 +13,8 @@ Claude Code skills that operate on KB-defined artifacts (decision records, TODO.
 | **pair** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |
 | **ping** | Probe skill for verifying skill discovery on deployment surfaces | None (returns a static token) |
 | **pr** | Create pull requests with smart base branch detection | Reads Linear tickets |
+| **align** | Bring a repo's conventions into alignment with KB standards | Reads/compares KB templates |
+| **figma-conventions** | Opinionated Figma workflow conventions for file organization and editing | None (conventions only) |
 
 ## Skills that stay in dotfiles
 
@@ -54,3 +56,59 @@ Skills deploy to multiple surfaces, each with different discovery mechanisms:
 Skills are authored in `skills/` (the canonical source) and copied to `.github/skills/` for GitHub Copilot discovery. The copies must stay in sync — the `check-skill-sync.yaml` CI workflow fails PRs if they diverge.
 
 **Important:** `.github/skills/` must contain real files, not symlinks. GitHub's cloud agent does not follow symlinks.
+
+## Portability guidelines
+
+Skills follow the [Agent Skills](https://agentskills.io) open standard (formerly "OpenSkills"). The format is supported by 35+ tools including Claude Code, OpenCode, GitHub Copilot, and Codex. These guidelines ensure skill bodies remain portable across tools and middleware (e.g. Composio) while preserving precision on the primary target.
+
+### Rule 1 — Use functional prose for tool references
+
+Skill body text must describe **what to do**, not which tool to call. LLMs resolve functional descriptions to the correct tool from their available set, regardless of platform.
+
+| Instead of | Write |
+|---|---|
+| "Use `AskUserQuestion` to confirm" | "Confirm with the user before proceeding" |
+| "Use `Read` to read the file" | "Read the file" |
+| "Run via `Bash`" | "Run in the shell" |
+| "Use `Grep` to search" | "Search file contents for the pattern" |
+| "Use `WebFetch` to fetch the URL" | "Fetch the URL content" |
+| "Use `Edit` / `Write` for code changes" | "Make the code changes" |
+| "Spawn a `Task` subagent to investigate" | "Investigate in parallel" |
+
+**Why:** Built-in tool names differ across platforms (Claude Code uses PascalCase `Read`, OpenCode uses lowercase `read`, others vary further). Functional prose works on all of them.
+
+### Rule 2 — Dual-layer references for MCP tools
+
+When referencing an MCP-provided tool (Linear, GitHub, Figma, etc.), lead with functional prose and optionally include the canonical MCP tool name in parentheses as a hint.
+
+| Instead of | Write |
+|---|---|
+| "Call `mcp__claude_ai_Linear__save_issue`" | "Update the issue on Linear (e.g. `save_issue`)" |
+| "Use `mcp__github__get_file_contents`" | "Read the file from GitHub (e.g. `get_file_contents`)" |
+| "Post via `mcp__claude_ai_Linear__save_comment`" | "Post a comment on the Linear issue (e.g. `save_comment`)" |
+
+**Why:** The `mcp__<server>__` prefix is a Claude Code namespacing convention — not portable. The canonical MCP name (e.g. `save_issue`) is consistent across MCP clients but not across middleware like Composio (which uses `LINEAR_CREATE_LINEAR_ISSUE`). Functional prose is the universal escape hatch; the parenthetical hint adds precision when the official MCP server is in use.
+
+**`allowed-tools` in frontmatter** keeps the full platform-specific prefix (e.g. `mcp__claude_ai_Linear__save_issue`). Frontmatter is where the platform needs exact names; body prose is where humans and LLMs need intent.
+
+### Rule 3 — Execution patterns are exempt
+
+Platform-specific execution patterns — skill-to-skill delegation, subagent spawning, HITL gates with specific parameter shapes — describe the skill's **architecture**, not a tool name. These stay as-is:
+
+- `Skill("comment", ...)` — skill invocation syntax
+- `Task` / `Agent` subagent spawning with `subagent_type` parameters
+- `AskUserQuestion` with specific option structures (the *call pattern*, not the *concept* of asking)
+
+The distinction: "confirm with the user" (Rule 1) describes intent. `AskUserQuestion({ question: "...", options: [...] })` describes a specific API shape that's part of the skill's control flow. The former is generalizable; the latter is architectural.
+
+### Rule 4 — `allowed-tools` stays in frontmatter
+
+The Agent Skills spec defines `allowed-tools` as an experimental field. Claude Code uses it actively to scope tool access during skill execution. Other tools ignore unknown frontmatter fields harmlessly. Keep it in frontmatter — do not move it to `metadata`.
+
+### Reviewing skills for portability
+
+When reviewing a skill change, check body text against these rules:
+
+1. **Scan for PascalCase tool names** — `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, `AskUserQuestion`. If they appear as "use X to..." instructions (not architectural patterns), rewrite to functional prose.
+2. **Scan for `mcp__` prefixes** — any `mcp__<server>__<tool>` in body text should be replaced with functional prose + parenthetical canonical name.
+3. **Leave execution patterns alone** — `Skill(...)`, `Task(...)`, `Agent(...)` invocation blocks with parameter examples are architectural and stay as-is.

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -79,7 +79,7 @@ For each migration step, check whether the target repo has already applied it:
 
 **Files:**
 - Does the file exist? Does its content match the expected pattern?
-- Use `Grep` for pattern matching (e.g. "does CONTRIBUTING.md have an 'AI Co-authorship' section?")
+- Search file contents for pattern matches (e.g. "does CONTRIBUTING.md have an 'AI Co-authorship' section?")
 - Compare against the KB template version for drift
 
 **Repo settings:**
@@ -88,7 +88,7 @@ For each migration step, check whether the target repo has already applied it:
 - Check observable settings via `gh api repos/{owner}/{repo}` if `gh` is available
 
 **Tickets:**
-- Fetch open issues from Linear (`list_issues` filtered by project/team)
+- Fetch open issues from Linear (e.g. `list_issues` filtered by project/team)
 - Run each title through the quality gate: imperative voice, verb tiers, statement detection, truncation check
 - Check descriptions for DoD presence
 - Flag scope issues: overly broad tickets, missing breakdown
@@ -192,7 +192,7 @@ Migration plan ({N} steps)
 Execute all auto steps? (manual/destructive steps are always individual)
 ```
 
-Use `AskUserQuestion` with options:
+Confirm with the user, offering these options:
 - **Execute all auto steps** — run all non-destructive automated steps, then present manual/destructive ones individually
 - **Step through one by one** — present each step for individual approval
 - **Skip to specific step** — jump to a numbered step
@@ -204,7 +204,7 @@ For each approved step:
 
 1. **Announce** what's about to happen and which resource type it affects.
 2. **Execute** the change:
-   - **File changes:** `Edit` / `Write` / `Bash` (for `git mv`, `git rm`)
+   - **File changes:** edit files in-place, write new files, or run shell commands (for `git mv`, `git rm`)
    - **Repo settings:** surface `gh` CLI commands for the operator. On explicit approval ("go ahead"), execute them. Never auto-execute external changes.
    - **Ticket changes:** delegate to the `/issue` skill for title rewrites and scope fixes. Present proposed changes and get approval before applying.
    - **Manual steps:** print instructions clearly. Mark as done only when the operator confirms they've completed it.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -62,7 +62,7 @@ The goal is to surface these issues once so the operator can fix them — not to
 
 ### Step 2 — Read the diff and check staging
 
-Run via `Bash`:
+Run in the shell:
 
 - `git status` — to see what's staged vs unstaged, untracked files
 - `git diff --cached` — staged changes (this is what `git commit` will include)
@@ -207,12 +207,12 @@ Base this on what the git history actually shows, reconciled with the org kb if 
 
 ### Step 3 — Confirm and write
 
-Use `AskUserQuestion` to confirm:
+Confirm with the user:
 
 - **Where to write:** CONTRIBUTING.md (create or append section) / AGENTS.md (append section) / README.md (append section) / Other
 - **Content looks good?** with the drafted section shown in chat
 
-On confirmation, write or append the section to the chosen file via `Write` or `Edit`.
+On confirmation, write or append the section to the chosen file.
 
 ### Step 4 — Done
 

--- a/skills/decision/SKILL.md
+++ b/skills/decision/SKILL.md
@@ -31,7 +31,7 @@ decision skill  →  decision record (with action items in canonical sections)  
 [HITL gate: human reviews, edits, greenlights the record]
   │
   ▼
-issue       →  proposes tickets in chat → confirms via AskUserQuestion → creates tickets
+issue       →  proposes tickets in chat → confirms with the user → creates tickets
   │
   ▼
 Linear: LIN-NNN annotations written back into the record
@@ -65,13 +65,13 @@ Heuristic: extract the 2–4 most distinguishing nouns/noun-phrases from the pro
 
 ## Tools declared in allowed-tools
 
-- `Task` — spawn parallel subagents for independent web research
-- `WebSearch`, `WebFetch` — direct research from the main agent when needed
-- `AskUserQuestion` — the one-shot batched-clarification tool
-- `Glob`, `Grep`, `Read` — scope discovery across `docs/decisions/**`, `docs/TODO.md`, `CLAUDE.md`
-- `Write`, `Edit` — creating new records and extending existing ones
+- Parallel subagents — investigate independent web research questions concurrently
+- Web search and page fetching — direct research from the main agent when needed
+- User clarification — the one-shot batched-clarification mechanism
+- File search and reading — scope discovery across `docs/decisions/**`, `docs/TODO.md`, `CLAUDE.md`
+- File writing and editing — creating new records and extending existing ones
 - Linear MCP read tools — discovering related tickets and existing Linear docs
-- `mcp__claude_ai_Linear__save_document` — for the strategy/process routing path
+- Linear document saving (e.g. `save_document`) — for the strategy/process routing path
 
 The `allowed-tools` declaration pre-approves tool *categories*. For scoped file writes, the user should configure Claude Code settings to pre-approve paths (see **Required grants** at the bottom).
 
@@ -104,11 +104,11 @@ Check `permissions.allow` for entries matching `Write(docs/decisions/**)` and `E
 > { "permissions": { "allow": ["Write(docs/decisions/**)", "Edit(docs/decisions/**)"] } }
 > ```
 
-Offer two options via `AskUserQuestion`: **Proceed with prompts** / **Bail — I'll configure first**. If the grants are present, skip this entirely.
+Offer two options to the user: **Proceed with prompts** / **Bail — I'll configure first**. If the grants are present, skip this entirely.
 
 ### Tool availability
 
-If `WebSearch`, `WebFetch`, `Task`, or the Linear MCP tools are unavailable for policy or environment reasons, degrade gracefully: produce a note based on existing context only, and flag in the Status Log that web/Linear/subagent research was skipped.
+If web search, page fetching, parallel subagents, or the Linear MCP tools are unavailable for policy or environment reasons, degrade gracefully: produce a note based on existing context only, and flag in the Status Log that web/Linear/subagent research was skipped.
 
 ## Phase 1 — Interpret and route
 
@@ -117,7 +117,7 @@ Restate the prompt in one or two sentences. Be explicit about the kind of design
 Then apply the **routing test** from the asabina kb framework:
 
 - **Code-adjacent** — architecture, implementation, tech stack, APIs, deployment, testing, tooling, developer experience, data model, security patterns → **repo** (`docs/decisions/`)
-- **Strategy / process / team** — business strategy, positioning, marketing/GTM, team process, product prioritization rationale, cross-project org decisions → **Linear document** (via `save_document`)
+- **Strategy / process / team** — business strategy, positioning, marketing/GTM, team process, product prioritization rationale, cross-project org decisions → **Linear document** (saved via Linear's document API, e.g. `save_document`)
 - **Ambiguous** → flag explicitly; ask in Phase 2 rather than silently defaulting
 
 The kb's key test: *"Does this decision affect how code is written, deployed, or maintained?"* → repo. *"Is this about what to build or how to operate as a team?"* → Linear.
@@ -136,8 +136,8 @@ Fan out read-only queries to discover what already exists. These can run in para
 
 1. **Tag-based note match.** Grep front matter `tags:` lines across `docs/decisions/**/*.md`. Derive candidate tags from the prompt's semantic core. Find notes whose tags overlap. Respect the **too-general guard** (below).
 2. **Content match.** Grep note titles and bodies for load-bearing keywords from the prompt.
-3. **Linear tickets.** `list_issues` filtered by keyword(s). Capture ticket IDs, titles, state, and project.
-4. **Linear documents** (only if Phase 1 leaned Linear-routed). `list_documents` filtered by keyword(s).
+3. **Linear tickets.** Search for related Linear issues (e.g. `list_issues`) filtered by keyword(s). Capture ticket IDs, titles, state, and project.
+4. **Linear documents** (only if Phase 1 leaned Linear-routed). Search for related Linear documents (e.g. `list_documents`) filtered by keyword(s).
 5. **TODO.md stubs.** Read `docs/TODO.md` and grep for related lines (look for existing stubs that link to design notes).
 6. **Related notes cross-graph.** For each candidate match, check its `## Related Design Notes` section for transitive matches.
 
@@ -164,9 +164,9 @@ For each choice: **ask** or **assume**?
 - **Ask** only when (a) the answer would materially change the research or output, AND (b) a reasonable default has a real chance of being wrong.
 - **Assume** everything else.
 
-Issue **all questions in a single `AskUserQuestion` call**. Prefer 0–3 questions; **4 is the hard cap**.
+Issue **all questions in a single clarification round**. Prefer 0–3 questions; **4 is the hard cap**.
 
-If you have zero questions, skip the tool call and write `**No clarification needed — proceeding directly.**` This is the walk-away contract: one interruption max.
+If you have zero questions, skip the clarification and write `**No clarification needed — proceeding directly.**` This is the walk-away contract: one interruption max.
 
 ### Typical Phase 2 question shapes
 
@@ -184,7 +184,7 @@ Write out the locked decisions explicitly. Format:
 > - **D4 (tags):** `layouts`, `abstraction`, `flutter` — *reused from vocabulary*
 > - **D5 (shape):** Add new `## Proposed Solutions` subsections; extend `## Open Questions` — *assumed*
 
-Aim for 4–8 decisions total. **After Phase 4 closes, no more questions for the rest of the run.** Anything that surfaces mid-research goes into the note's `## Open Questions` section, not into a new `AskUserQuestion` call.
+Aim for 4–8 decisions total. **After Phase 4 closes, no more questions for the rest of the run.** Anything that surfaces mid-research goes into the note's `## Open Questions` section, not into a new clarification round.
 
 ## Phase 5 — Research execution
 
@@ -310,7 +310,7 @@ If a claim genuinely has no linkable source (e.g. a conclusion you reasoned to, 
 
 ### Linear doc mode (routing test sent this to Linear)
 
-1. Use `save_document` to create or update a Linear document in the workspace.
+1. Save the document to Linear (e.g. `save_document`) to create or update a Linear document in the workspace.
 2. Content structure mirrors the repo template adapted for Linear's markdown:
    - `# Title`
    - Inline metadata block (tags, date, author) — Linear docs don't support front matter
@@ -367,6 +367,6 @@ The skill's `allowed-tools` declaration pre-approves the tool categories it need
 }
 ```
 
-Linear MCP tools are declared in `allowed-tools` and should not require per-call approval. The strategy-routing path uses `save_document` which needs Linear write access — same grant.
+Linear MCP tools are declared in `allowed-tools` and should not require per-call approval. The strategy-routing path saves documents to Linear which needs Linear write access — same grant.
 
 If these paths aren't pre-approved, the skill will still work but will prompt on each write, breaking the walk-away UX. Configure them before running the skill for the first time.

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -13,7 +13,7 @@ The defining design principles of this skill are:
 
 > **The design note is the single source of truth. The skill reads it, derives tickets, and writes Linear ticket IDs back into it. No parallel work-plan file. No re-modeling.**
 >
-> **Confirm in chat, not via files.** The skill prints proposed tickets in the conversation, confirms with one `AskUserQuestion`, and creates on approval. One invocation, one session.
+> **Confirm in chat, not via files.** The skill prints proposed tickets in the conversation, confirms with the user in one shot, and creates on approval. One invocation, one session.
 >
 > **Idempotent re-runs.** A note that's already been linearized has inline `Linear: LIN-NNN` annotations. The skill detects them and updates instead of duplicating.
 >
@@ -34,7 +34,7 @@ decision skill  →  design note (with action items in canonical sections)
 issue       →  prints proposed tickets in chat
   │
   ▼
-[HITL gate: AskUserQuestion confirmation]
+[HITL gate: user confirmation]
   │
   ▼
 creates tickets + writes Linear: LIN-NNN annotations back into the note
@@ -44,13 +44,13 @@ The human gate on the design note itself is where the real review happens. By th
 
 ## Tools declared in allowed-tools
 
-- `Glob`, `Grep`, `Read` — discover and parse the design note
-- `Edit` — append cross-references and Status Log rows back to the note
-- `WebFetch` — follow URLs referenced in the note when enriching ticket descriptions
-- `AskUserQuestion` — the confirmation gate (and batched clarification if needed)
+- File discovery and reading tools (`Glob`, `Grep`, `Read`) — discover and parse the design note
+- File editing tool (`Edit`) — append cross-references and Status Log rows back to the note
+- URL fetching (`WebFetch`) — follow URLs referenced in the note when enriching ticket descriptions
+- User confirmation (`AskUserQuestion`) — the confirmation gate (and batched clarification if needed)
 - Linear MCP read tools — search for existing tickets, resolve teams/projects, look up statuses and labels
 - `Skill` — invoke the `comment` skill for posting comments to Linear issues
-- Linear MCP write tools — `save_issue`
+- Linear MCP write tools — create or update the issue on Linear (e.g. `save_issue`)
 
 The skill does not declare `Task` — there is no parallel research phase. Ticket derivation is deterministic and serial.
 
@@ -76,7 +76,7 @@ If a tool or command is available to rename the session programmatically, use it
 
 ### Triage: check for duplicates and scope overlap
 
-Before creating any new issue — whether from a design note or freeform — run a tiered check to avoid duplicates, scope overlap, and contradictions in the backlog. This applies in both filing mode and when other skills (pair, freeform conversation) route through `save_issue` to create a ticket.
+Before creating any new issue — whether from a design note or freeform — run a tiered check to avoid duplicates, scope overlap, and contradictions in the backlog. This applies in both filing mode and when other skills (pair, freeform conversation) route through issue creation to create a ticket.
 
 **Tier 0 — Project fit (always run, before anything else):**
 
@@ -92,19 +92,19 @@ When filing a batch, run the check per ticket — different items may route to d
 
 **Tier 1 — Current work (always run, lightweight):**
 - Check the current branch and the last 2 branches worked on (`git branch --sort=-committerdate | head -3`).
-- Cross-reference with GitHub (`mcp__github__list_pull_requests`, `mcp__github__pull_request_read`) to confirm merge state — local state may be stale.
+- Cross-reference with GitHub — list pull requests and read PR details (e.g. `list_pull_requests`, `pull_request_read`) to confirm merge state — local state may be stale.
 - If an in-progress branch covers this scope, surface it: "This looks like it fits in VID-XYZ which is still on branch X — want me to fold it in?"
 
 **Tier 2 — Related issues (always run):**
-- If a ticket ID is known (from the branch name, the design note, or the user's prompt), fetch it and check its related issues (`get_issue` with `includeRelations: true`).
+- If a ticket ID is known (from the branch name, the design note, or the user's prompt), fetch the issue from Linear (e.g. `get_issue`) with relations included and check its related issues.
 - Scan the related issues for scope overlap or contradictions with the proposed new ticket.
 
 **Tier 3 — Backlog scan (run when the issue is complex or duplicates seem likely):**
-- Search the project backlog (`list_issues` filtered by project and team) for tickets with similar titles or keywords.
+- Search for related issues on Linear (e.g. `list_issues`, filtered by project and team) for tickets with similar titles or keywords.
 - If matches are found, present them: "These existing tickets look related — should we extend one of them, or is this genuinely new?"
 - Propose resolution: merge scopes, re-prioritize an existing ticket, mark as duplicate, or confirm isolation.
 
-If the triage surfaces a match, present options via `AskUserQuestion`:
+If the triage surfaces a match, ask the user to choose:
 - **Fold into VID-XYZ** — add scope to the existing ticket (comment the new context)
 - **Stack on VID-XYZ** — create as a sub-issue or related issue
 - **Mark as duplicate** — set `duplicateOf` on the old ticket, transition to Cancelled, and **comment why** on the cancelled ticket (see cancellation rule below)
@@ -148,7 +148,7 @@ Check `permissions.allow` for entries matching `Edit(docs/decisions/**)`. If the
 >
 > Proceed anyway, or bail and configure first?
 
-Offer two options via `AskUserQuestion`: **Proceed with prompts** / **Bail — I'll configure first**. If the grant is present, skip this entirely.
+Ask the user to choose: **Proceed with prompts** / **Bail — I'll configure first**. If the grant is present, skip this entirely.
 
 ### Verify the note
 
@@ -253,13 +253,13 @@ Skipped:
 
 ### Confirm
 
-Issue one `AskUserQuestion` call. Combine the confirmation with any unresolved routing questions from Phase 2 into a single batch:
+Confirm with the user. Combine the confirmation with any unresolved routing questions from Phase 2 into a single batch:
 
 - **Always ask:** "Create these {N} tickets?" with options: **Yes, create all** / **Exclude some — let me pick** / **Bail**
 - **Only if team/project is unresolved:** include a question for team and/or project selection
 - **Only if candidate count is large (>10):** include a question about narrowing scope
 
-If the user chooses "Exclude some", issue one follow-up `AskUserQuestion` with multiSelect listing the candidates so the user can deselect. This is the only case where a second question is permitted.
+If the user chooses "Exclude some", ask one follow-up question with multiSelect listing the candidates so the user can deselect. This is the only case where a second question is permitted.
 
 If the user bails, stop. Print nothing further.
 
@@ -268,7 +268,7 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences of context followed by a **"Done when:" checklist** — a markdown checkbox list where each item is a concrete, verifiable condition. Use checklist style (`- [ ] condition`) not prose style ("Done when X is true"). Checklist items can be checked off as they're completed, giving visibility into partial progress. Each item should be specific enough that someone can check it without reading the full context. Example:
+2. **Create:** create the issue on Linear (e.g. `save_issue`) with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–5 sentences of context followed by a **"Done when:" checklist** — a markdown checkbox list where each item is a concrete, verifiable condition. Use checklist style (`- [ ] condition`) not prose style ("Done when X is true"). Checklist items can be checked off as they're completed, giving visibility into partial progress. Each item should be specific enough that someone can check it without reading the full context. Example:
    ```
    **Done when:**
    - [ ] Export existing data as CSV
@@ -276,21 +276,21 @@ For each confirmed ticket:
    - [ ] Document migration steps in README
    ```
    Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
-3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
+3. **Update:** update the issue on Linear (e.g. `save_issue`) with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
 ### Write back to the note
 
-After all `save_issue` calls succeed:
+After all issue creation calls succeed:
 
 5. **Re-read the note** (in case of any concurrent edits, though unlikely).
 6. **Append `Linear: LIN-NNN` cross-references.** For each newly-created ticket, find the source action item line in the note and append ` (Linear: [LIN-NNN]({url}))` immediately after the item text. For multi-line items, append on a new line indented to the item's level.
 7. **Append a Status Log row** to the note: today's date, `claude` as author, the comma-separated list of created/updated ticket IDs in the Related Tickets column, and a Notes column summary like "Filed N tickets via issue (M new, K updated)".
-8. **Save the note** via `Edit`.
+8. **Save the note** by editing the file in place.
 
 ### Partial failure
 
-If any `save_issue` call fails partway through:
+If any issue creation call fails partway through:
 
 - Stop the loop. Do not roll back successful tickets.
 - Print which tickets succeeded and which failed.
@@ -312,8 +312,8 @@ Entered when Phase 0 detects a Linear URL or issue ID. The filing-mode phases (1
 ### Load the issue
 
 Fetch in parallel:
-- `get_issue` — title, description, status, labels, priority
-- `list_comments` — full comment thread, ordered by `createdAt`
+- Fetch the issue from Linear (e.g. `get_issue`) — title, description, status, labels, priority
+- Fetch existing comments (e.g. `list_comments`) — full comment thread, ordered by `createdAt`
 
 Print a compact header so the user can confirm you're looking at the right thing:
 
@@ -345,16 +345,16 @@ Print both drafts in chat before asking for confirmation. Make it easy to scan.
 
 ### Confirm and write
 
-Issue one `AskUserQuestion` with:
+Confirm with the user:
 - **Always:** "Post this comment?" — **Yes** / **Edit first** / **Skip**
 - **Only if an anchor update was drafted:** "Apply the title/description update?" — **Yes** / **Edit first** / **Skip**
 
-Both questions can be batched into a single `AskUserQuestion` call.
+Both questions can be batched into a single confirmation.
 
 On "Edit first": ask what to change, revise, re-present, confirm again.
 
 On approval, write in this order:
-1. `save_issue` for any title/description changes (only if confirmed)
+1. Update the issue on Linear (e.g. `save_issue`) for any title/description changes (only if confirmed)
 2. `Skill("comment", ...)` to delegate the comment to the comment skill (only if confirmed) — describe the issue ID, comment title (e.g. "Assessment", "Context", "Scope refinement"), the originating skill name ("issue"), and the comment body. The comment skill handles formatting, provenance, and threading.
 
 ### Summary
@@ -418,14 +418,14 @@ If any title triggered the quality gate, show both versions:
            Warning: mechanism verb 'Implement' leading
 ```
 
-Issue one `AskUserQuestion`: "Create these {N} issues?" with options: **Yes, create all** / **Exclude some** / **Edit titles** / **Bail**
+Ask the user: "Create these {N} issues?" with options: **Yes, create all** / **Exclude some** / **Edit titles** / **Bail**
 
 - **Edit titles** — the user provides corrections; revise and re-present.
-- **Exclude some** — one follow-up `AskUserQuestion` with multiSelect.
+- **Exclude some** — one follow-up question with multiSelect.
 
 ### Create tickets
 
-For each confirmed ticket, call `save_issue` with team, project, title, description, priority, and labels. The same rules as filing mode apply:
+For each confirmed ticket, create the issue on Linear (e.g. `save_issue`) with team, project, title, description, priority, and labels. The same rules as filing mode apply:
 
 - Descriptions are minimal anchors (2–4 sentences max)
 - Prepend `*[ai:claude-code]*` to the description
@@ -581,11 +581,11 @@ Warning:   <what triggered — e.g. "mechanism verb 'Implement' leading", "78 ch
 - **Don't skip the DoD.** Every ticket needs a "Done when:" checklist in the description — markdown checkboxes (`- [ ] condition`), not a prose sentence. Each item should be concrete and verifiable — not "done when implemented" but specific observable conditions. Checklist style enables partial-progress tracking (items can be checked off as completed). If the source material doesn't imply clear DoD items, draft them from the action item's intent and surface them in the confirmation gate for the user to refine.
 - **Don't default to description updates in iteration mode.** The user's intent is almost always to add a comment. Only propose a title/description change when the prompt explicitly targets the anchor (e.g. "the title is wrong", "rewrite the description"). When in doubt, put it in a comment.
 - **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
-- **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
+- **Don't silently rewrite comment history.** The skill can only post new comments on the issue (e.g. `save_comment`). It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
-- **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `decision`.
+- **Don't follow URLs unbounded.** Only fetch URLs to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `decision`.
 - **Don't cancel or duplicate tickets without commenting why.** Every state change that removes a ticket from the active backlog must carry a comment explaining the reason. A cancelled ticket with no explanation is a dead end for backlog reviewers. See the cancellation rule in Phase 0.
-- **Don't move issues across teams without setting team and project together.** Always set both in a single `save_issue` call to avoid transient inconsistency where the issue sits in a team that doesn't own the target project.
+- **Don't move issues across teams without setting team and project together.** Always set both in a single issue update call to avoid transient inconsistency where the issue sits in a team that doesn't own the target project.
 
 ## Required grants
 
@@ -603,4 +603,4 @@ The skill's `allowed-tools` declaration pre-approves the tool categories. For sc
 
 The skill checks for this grant in Phase 0 and warns if it's missing.
 
-Linear MCP write tool (`save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("comment", ...)`, which requires the `Skill` tool to be allowed so the comment skill can be invoked.
+The Linear MCP write tool for issue creation (e.g. `save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("comment", ...)`, which requires the `Skill` tool to be allowed so the comment skill can be invoked.

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -81,10 +81,10 @@ If the user passed a branch name directly rather than a ticket ID, check it out 
 
 Once the ticket ID is known and the branch is checked out, fetch all of these in parallel:
 
-- **Linear ticket:** `get_issue` with the ticket ID. Capture title, description, state, priority, labels, project, parent issue.
-- **Linear comments:** `list_comments` — read existing comments. If a previous pair session left assessment/plan/spike comments, note them. This is the resumption path.
+- **Linear ticket:** fetch the Linear issue (e.g. `get_issue`) with the ticket ID. Capture title, description, state, priority, labels, project, parent issue.
+- **Linear comments:** fetch existing comments (e.g. `list_comments`) — read existing comments. If a previous pair session left assessment/plan/spike comments, note them. This is the resumption path.
 - **Branch state:** `git log --oneline -10`, `git status`, `git diff main...HEAD` (or appropriate base branch) to understand what's already been done on this branch.
-- **Codebase orientation:** Use `Task` with `subagent_type: Explore` to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
+- **Codebase orientation:** Use a subagent to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
 - **Repo conventions:** Read `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` at the repo root for development workflow, testing, and quality requirements.
 
 ### Branch fit check
@@ -95,7 +95,7 @@ After loading context, compare the files the planned work will touch against the
 
 Detected when a planned change touches files unrelated to the current branch's purpose (e.g. fixing an unrelated bug, adding a feature that belongs on a different ticket).
 
-- **Checkpoint mode:** Surface to the navigator before doing anything. Present three options via `AskUserQuestion`: (a) continue on the current branch, (b) navigator cuts a new branch, (c) file a ticket and defer. Wait for the answer before proceeding.
+- **Checkpoint mode:** Surface to the navigator before doing anything. Present three options and ask the user: (a) continue on the current branch, (b) navigator cuts a new branch, (c) file a ticket and defer. Wait for the answer before proceeding.
 - **Yolo mode:** Create a local `tmp/<slugified-title>` branch and continue work there. Do **not** push it. At session wrap-up, surface it: "I branched off `tmp/<slug>` for this out-of-scope work — file a ticket and rename it, or drop it?" On drop: run `git branch -D tmp/<slug>` and log what was discarded.
 
 Guards: never push a `tmp/` branch. Never cut a named branch or file a ticket autonomously — both are HITL actions.
@@ -113,7 +113,7 @@ If no mismatch is detected, proceed without comment.
 
 ### Transition to In Progress
 
-After the branch is checked out and the ticket is loaded, call `save_issue` with `id: {ticket-id}` and `state: "In Progress"`. Do this unconditionally — picking up the branch is the signal that work has started. No comment needed; the state change speaks for itself.
+After the branch is checked out and the ticket is loaded, update the issue on Linear (e.g. `save_issue`) with `id: {ticket-id}` and `state: "In Progress"`. Do this unconditionally — picking up the branch is the signal that work has started. No comment needed; the state change speaks for itself.
 
 ### Rename the session
 
@@ -182,7 +182,7 @@ Store the returned anchor comment ID — spike findings and other assessment fol
 
 ### Spike on feasibility (parallel)
 
-For each feasibility unknown, spawn a `Task` subagent to investigate:
+For each feasibility unknown, spawn a subagent to investigate:
 
 - Read relevant source code, docs, or external references
 - Try small proof-of-concept explorations (read-only or in scratch space)
@@ -260,7 +260,7 @@ Blocked:
  (none)
 ```
 
-Use `AskUserQuestion` for the items that need input. In pair programming, asking questions as they arise is expected. Batch questions that are ready at the same time rather than asking them one by one.
+Ask the user for the items that need input. In pair programming, asking questions as they arise is expected. Batch questions that are ready at the same time rather than asking them one by one.
 
 ## Phase 2 — Plan the work
 
@@ -329,9 +329,9 @@ For each step:
 
 1. **Announce** what you're about to do. "Starting Step 1 — adding the OAuth callback route."
 2. **Branch fit check.** Before touching any files, verify this step's files fit the branch purpose. Apply the Category A / Category B protocols from the Phase 0 branch fit check if a mismatch is detected.
-3. **Implement** the change. Use `Edit` / `Write` for code changes.
+3. **Implement** the change. Make the code changes.
 4. **Decision record maintenance.** If the step touches a file in `docs/decisions/`, append a Status Log row: today's date, `claude` as author, the ticket ID in Related Tickets, and a concise note stating *what changed and why* — not just that an edit happened. Bake the purpose in so the row is scannable on its own (e.g. "Added disclosure-provider pricing comparison via pair KB-9", not a bare "Updated via pair KB-9"). This keeps the record's audit trail intact. If the step writes research or spike findings into the record (or any doc), apply the **Source-linking** rule from Phase 1 — every finding links inline to its source.
-5. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
+5. **Run quality checks** if the repo has them (lint, typecheck, test). Run these in the shell. If a check fails, fix it before presenting.
 6. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
 7. **Draft commit message.** In both modes, delegate to the `/commit` skill for message drafting. The `/commit` skill handles convention lookup, type/scope selection, atomicity checks, and message formatting. Never draft commit messages freehand.
 8. **Checkpoint.**
@@ -355,7 +355,7 @@ Commit: `a1b2c3d`")
 
 ### Parallel execution
 
-When the plan has independent steps, use `Task` subagents to work on them concurrently:
+When the plan has independent steps, use subagents to work on them concurrently:
 
 - Each subagent receives the full plan context and its assigned step
 - Each subagent writes its changes and runs its tests
@@ -415,7 +415,7 @@ If there are uncommitted changes (checkpoint mode only):
 
 ### PR creation
 
-If the branch looks complete relative to the ticket scope, **delegate to the `/pr` skill.** Do not duplicate PR creation logic here — invoke it via the `Skill` tool with `skill: "pr"`.
+If the branch looks complete relative to the ticket scope, **delegate to the `/pr` skill.** Do not duplicate PR creation logic here — invoke it via the skill system with `skill: "pr"`.
 
 The `/pr` skill handles: base branch detection (including stacked PRs), drafting the title and body from commits and the Linear ticket, pitching in chat for approval, pushing, creating via `gh`, transitioning the ticket to In Review, launching a background CI monitor, and **merge strategy** (convention reading, stack-aware merging, closing keyword bookkeeping). Do not duplicate merge logic here.
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -23,7 +23,7 @@ Run in parallel:
 - **Branch:** `git branch --show-current`
 - **Commits on branch:** `git log --oneline main..HEAD` (or `git log --oneline HEAD ^origin/main` if on remote)
 - **Push state:** `git status -sb` — is the branch already pushed to origin?
-- **Remote default branch:** use `mcp__github__get_file_contents` or `mcp__github__list_branches` to determine the default branch — don't hardcode `main`
+- **Remote default branch:** read the file from GitHub (e.g. `get_file_contents`) or list branches (e.g. `list_branches`) to determine the default branch — don't hardcode `main`
 - **Repo merge conventions:** Read `AGENTS.md` and `CONTRIBUTING.md` at the repo root (if they exist) for merge strategy guidance — e.g. squash vs merge commit, stack handling, branch cleanup. Store any findings for use in Phase 6.
 - **Repo config:** Check for `.github-settings.yaml` at the repo root (see Phase 1.1 below).
 
@@ -41,7 +41,7 @@ Check for `.github-settings.yaml` at the repo root. This file declares the repo'
 
 **If `.github-settings.yaml` exists:**
 
-Read it and store the declared settings for use in Phase 6 (merge strategy). Compare against what's observable from the GitHub API (e.g. allowed merge methods via `mcp__github__search_repositories`). If a mismatch is detected, surface it as a warning in the Phase 4 pitch:
+Read it and store the declared settings for use in Phase 6 (merge strategy). Compare against what's observable from the GitHub API (e.g. allowed merge methods by querying repository settings from GitHub (e.g. `search_repositories`)). If a mismatch is detected, surface it as a warning in the Phase 4 pitch:
 
 ```
 ⚠️  Repo config drift detected:
@@ -102,7 +102,7 @@ Fields:
    Fix:
      gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_title=PR_TITLE
    ```
-2. **On operator request: run the commands directly.** If the operator says "go ahead" or "fix it", the skill executes the `gh` commands itself. Use `AskUserQuestion` to gate — never auto-fix drift without explicit approval.
+2. **On operator request: run the commands directly.** If the operator says "go ahead" or "fix it", the skill executes the `gh` commands itself. Confirm with the user to gate — never auto-fix drift without explicit approval.
 3. **Never silently modify.** Even in yolo mode, repo settings changes require an explicit gate. These are org-wide side effects, not branch-scoped changes.
 
 ## Phase 2 — Detect base branch
@@ -253,7 +253,7 @@ Create this PR? yes / edit / cancel
 
 If the title quality gate fired, the `Suggested:` and `Warning:` lines appear. The operator can accept the original, use the suggestion, or type their own via the `edit` flow. If no issues were detected, omit those lines.
 
-Use `AskUserQuestion` to get the response. Options:
+Ask the user for their response. Options:
 - **yes** → proceed to Phase 5
 - **edit** → the operator pastes corrections; apply them and re-pitch
 - **cancel** → stop, no PR created
@@ -270,7 +270,7 @@ Use `AskUserQuestion` to get the response. Options:
    ```
    **Do NOT use `mcp__github__create_pull_request` for PR creation.** The MCP tool escapes newlines as literal `\n` in the body parameter, producing a single-line wall of text on GitHub. This was observed on multiple PRs (yo-convo-bot#50, ivos-trades#4) and is a known limitation of how the MCP tool serializes multi-line strings. The `gh` CLI with heredocs preserves actual newlines. Other GitHub MCP tools (read, update, merge) are fine — the issue is specific to the `body` field on `create_pull_request`.
 3. **Print the PR URL** from the `gh` output.
-4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
+4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, update the issue on Linear (e.g. `save_issue`) with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
 
 ## Phase 6 — Monitor CI
 
@@ -278,7 +278,7 @@ After the PR is created, launch a **background subagent** to monitor CI status. 
 
 The subagent should:
 
-1. **Poll CI checks** using `mcp__github__pull_request_read` periodically or `Bash` with `gh pr checks <pr-number> --watch` until all checks complete or a timeout (10 minutes) is reached.
+1. **Poll CI checks** by reading the PR details from GitHub (e.g. `pull_request_read`) periodically or `Bash` with `gh pr checks <pr-number> --watch` until all checks complete or a timeout (10 minutes) is reached.
 2. **On all checks green:**
    - Report to the user: "CI passed on PR #N. Ready to merge."
    - Determine the merge strategy (see **Merge strategy** below).
@@ -290,7 +290,7 @@ The subagent should:
      4. Transition linked tickets to Done.
 3. **On any check red:**
    - Report the failure: which check failed, link to the logs.
-   - Fetch the failure details via `mcp__github__pull_request_read` and `Bash` with `gh run view <run-id> --log-failed` for actionable output.
+   - Fetch the failure details by reading the PR from GitHub (e.g. `pull_request_read`) and `Bash` with `gh run view <run-id> --log-failed` for actionable output.
    - Summarize what went wrong and suggest next steps (e.g. "lint failure in X — fixable here" or "test timeout — needs investigation").
    - Ask the user how to proceed: fix it now (resume pair), investigate further, or leave it for later.
 4. **On timeout (no checks appear within 2 minutes):**
@@ -330,12 +330,12 @@ The skill must determine *how* to merge before offering the merge action. The de
    NO  → continue to step 2
 
 2. Can the repo's merge method be detected from GitHub settings?
-   (e.g. via mcp__github__search_repositories → allowed merge types)
+   (e.g. by querying repository settings from GitHub (e.g. `search_repositories`) → allowed merge types)
    YES → use it as the default, but still surface to operator
    NO  → ask the operator: "No merge strategy documented. Squash, merge commit, or rebase?"
 ```
 
-**When repo convention conflicts with best-practices** (e.g. convention says squash but the PR is part of a stack that would lose traceability), surface the conflict to the operator via `AskUserQuestion`. Never silently override the repo convention — and never silently follow it when it would cause harm. Present the trade-off and let the operator decide.
+**When repo convention conflicts with best-practices** (e.g. convention says squash but the PR is part of a stack that would lose traceability), surface the conflict to the operator by asking the user. Never silently override the repo convention — and never silently follow it when it would cause harm. Present the trade-off and let the operator decide.
 
 ### Stack-aware merging
 
@@ -391,7 +391,7 @@ Group by platform on separate lines for readability. GitHub parses `#N` (numeric
 - **Don't create the PR without pitching.** The operator must see and approve the draft.
 - **Don't fabricate the test plan.** Derive it from the diff or say "verify manually" — don't invent test steps that don't exist.
 - **Don't push without noting it.** If a push is needed, say so before running it.
-- **Don't ask more than one round of questions.** All clarification happens in the pitch → edit loop, not via separate `AskUserQuestion` calls before Phase 4.
+- **Don't ask more than one round of questions.** All clarification happens in the pitch → edit loop, not via separate user prompts before Phase 4.
 - **Don't suggest merging before CI is green.** A freshly created PR has no check data. Wait for the CI monitor subagent to report results before offering merge options.
 - **Don't merge a stack tip with squash.** Squash-merging only the tip of a linear stack collapses N PRs into 1 commit — intermediate ticket IDs, PR boundaries, and review context are lost. For squash repos, always merge each PR individually, bottom-up.
 - **Don't merge without surfacing the strategy.** Always tell the operator what merge method and stack handling you're about to use, and wait for confirmation. Never silently default.


### PR DESCRIPTION
## Summary
- Add portability guidelines to `skills/README.md` — 4 rules for writing tool references that work across Claude Code, OpenCode, GitHub Copilot, and middleware like Composio
- Cross-reference the guidelines from CLAUDE.md and CONTRIBUTING.md for discoverability
- Generalize ~70 platform-specific tool name references across 7 skills to functional prose and dual-layer MCP references

## Test plan
- [ ] Verify skills still load correctly on Claude Code (tool names in `allowed-tools` frontmatter unchanged)
- [ ] Spot-check that generalized prose reads naturally and preserves intent
- [ ] Confirm cross-references in CLAUDE.md and CONTRIBUTING.md link to `skills/README.md`

https://linear.app/asabina/issue/KB-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)