### PR TITLE
feat(skills): add design skill for visual design workflow orchestration [KB-77]

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -8,6 +8,7 @@ Claude Code skills that operate on KB-defined artifacts (decision records, TODO.
 |-------|---------|---------------------|
 | **comment** | Post structured comments to Linear issues (threading, provenance, formatting) | None (protocol only) |
 | **commit** | Guide full commit unit: message drafting, type/scope selection, atomicity, staging, amend-vs-new | Reads CONTRIBUTING.md, AGENTS.md |
+| **design** | Orchestrate visual design workflows: DESIGN.md tokens → imagegen → direction selection → Figma implementation → feedback | Reads DESIGN.md, outputs to `.imagegen-output/` |
 | **decision** | Draft or extend decision records in `docs/decisions/` | Writes `docs/decisions/*.md` |
 | **issue** | File Linear issues from decision record action items, iterate on tickets, or create freeform | Reads/edits `docs/decisions/*.md` |
 | **pair** | Interactive pair-programming on Linear tickets | Reads CLAUDE.md, AGENTS.md, CONTRIBUTING.md |

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -18,6 +18,18 @@ The defining design principles:
 > **Generate fast, implement slow.** Image generation is cheap (~2 min/variant). Figma vector work is expensive (~15-30 min/direction). Exhaust the ideation space with imagegen before committing to Figma implementation.
 >
 > **References, not assets.** Generated images are compositional references — layout, mood, tension. They are never imported into Figma as final artwork. The Figma implementation is built from components, variables, and vectors.
+>
+> **Eyes on every artifact.** The agent must actually view every design output — read generated images, capture Figma screenshots — and process the visual content before presenting to the navigator. Design review requires seeing, not just describing.
+
+## Model quality for design work
+
+Design tasks — especially visual review, composition analysis, and nuanced aesthetic judgment — benefit from higher-quality models. When the design skill is active:
+
+1. **Detect the current model.** If the session is running on a fast/lite model (e.g. Haiku, Sonnet), note that design review quality may be limited.
+2. **Suggest escalation for tricky work.** When the task involves reviewing generated images for compositional quality, comparing reference vs implementation, or making subtle aesthetic judgments, suggest the navigator switch to a higher-grade model:
+   > "This comparison needs careful visual judgment. Consider switching to a higher-quality model (`/model opus` or similar) for this review phase — you can switch back after."
+3. **Self-select when possible.** If the agent platform supports per-task model selection (e.g. spawning a subagent at a higher tier), prefer that over asking the navigator to reconfigure. The design review subagent runs at higher quality; the mechanical work stays on the current model.
+4. **Don't nag.** Suggest once per session. If the navigator declines, proceed on the current model without further mention.
 
 ## Phase 0 — Load the design context
 
@@ -233,7 +245,7 @@ When the navigator is satisfied (or the session ends):
 ## Anti-patterns
 
 - **Don't skip DESIGN.md.** If it exists, read it. Brand tokens are not optional context — they're the constraint space the design lives in.
-- **Don't auto-advance past visual checkpoints.** Every generated image and every Figma change needs navigator review. Design is subjective — the agent cannot evaluate aesthetic quality.
+- **Don't auto-advance past visual checkpoints.** Every generated image and every Figma change needs navigator review. Design is subjective — the agent cannot evaluate aesthetic quality. Crucially, the agent must **actually view** every design artifact: read generated PNG files inline, capture Figma screenshots via `get_screenshot` or `await node.screenshot()`, and process the visual content before presenting it to the navigator. "I saved the image to X" without viewing it is insufficient — the agent should describe what it sees and flag any obvious issues (wrong colors, empty frame, clipped content) before the navigator even looks.
 - **Don't import generated images into Figma.** They are references, not assets. Build from components and vectors.
 - **Don't hardcode colors.** Always use DESIGN.md tokens → Figma variables. If a color isn't in DESIGN.md, flag it to the navigator rather than inventing one.
 - **Don't over-generate.** 2-3 variants per round is enough. 10 variants overwhelm the navigator and waste API calls. If the direction is clear, one variant is fine.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: design
+description: "Use this skill when the user wants to do visual design work — exploring brand graphics, creating Figma compositions, iterating on visual concepts, or working through a design-focused ticket. Trigger for prompts like 'design this', 'explore visual directions', 'let's do some design work', 'work on the brand graphic', 'iterate on the cover art', 'design exploration for X', or when /pair detects a design-focused ticket and delegates here. This skill orchestrates the full visual design workflow: reading brand tokens from DESIGN.md, generating concept images via /imagegen, selecting directions with the navigator, implementing in Figma via figma-conventions, and iterating through feedback loops. Do NOT trigger for code-only UI work (that's /pair territory), for writing DESIGN.md itself (edit directly), or for Figma file organization without a design goal (that's figma-conventions alone)."
+---
+
+# design
+
+Orchestrate visual design work. **You drive the tools, the navigator drives the aesthetics.**
+
+This skill coordinates the full visual design workflow — from brand tokens to generated concepts to Figma vectors. It delegates to specialized skills (`/imagegen`, `/figma-conventions`, `/decision`) rather than duplicating them, and owns the transitions between phases.
+
+The defining design principles:
+
+> **The navigator is the art director.** Every visual decision — color, composition, mood, direction — is theirs. The agent proposes, generates, and implements; the navigator steers and approves. Never auto-advance past a visual checkpoint.
+>
+> **Brand tokens are the foundation.** Every design session starts from DESIGN.md. Colors, typography, and spacing are not invented per-session — they're read from the canonical source. Deviations are flagged, not silently applied.
+>
+> **Generate fast, implement slow.** Image generation is cheap (~2 min/variant). Figma vector work is expensive (~15-30 min/direction). Exhaust the ideation space with imagegen before committing to Figma implementation.
+>
+> **References, not assets.** Generated images are compositional references — layout, mood, tension. They are never imported into Figma as final artwork. The Figma implementation is built from components, variables, and vectors.
+
+## Phase 0 — Load the design context
+
+### Read DESIGN.md
+
+Read `DESIGN.md` at the repo root. Extract and summarize the brand tokens the navigator will need:
+
+- **Colors:** core palette (background, surface, text, accent, semantic)
+- **Typography:** type ramp (families, sizes, weights)
+- **Spacing:** if defined
+- **Any brand-specific vocabulary** (logo shapes, motifs, naming conventions)
+
+If `DESIGN.md` doesn't exist, warn:
+
+> "No DESIGN.md found. I'll work without brand tokens — colors and typography will be freehand. Consider creating one via the DESIGN.md spec."
+
+### Check imagegen prereqs
+
+Verify `GEMINI_API_KEY` is available in the environment. If not, prompt per the imagegen skill's credential discovery flow. Don't block the session if the navigator wants to skip imagegen and go straight to Figma.
+
+### Load the ticket (if invoked via /pair passthrough)
+
+If this skill was invoked with a ticket ID (from `/pair` delegation or direct invocation), fetch the Linear issue and existing comments. Present a compact summary like pair does:
+
+```
+Design session: KB-67 — Design reusable pitch deck components
+Status: In Progress | Priority: Low
+
+Brand context (from DESIGN.md):
+  Accent: #ff5583 | Background: #000000 | Text: #ffffff
+  Type: Inter, 6-tier ramp (96px → 14px)
+
+Prior work:
+> [Summary from Linear comments if any]
+```
+
+If no ticket, this is a freeform design session — skip the ticket context.
+
+### Present the phases
+
+```
+Design workflow:
+  1. Concept  — generate visual candidates with imagegen
+  2. Select   — review candidates, pick a direction
+  3. Build    — implement the chosen direction in Figma
+  4. Refine   — screenshot, compare, iterate
+
+Start with concepting, or jump to a specific phase?
+```
+
+The navigator can enter at any phase. If they already have a direction in mind, skip straight to Build. If they have a Figma file in progress, skip to Refine.
+
+## Phase 1 — Concept
+
+### Build the prompt from brand context
+
+When generating images, automatically weave in the brand tokens from DESIGN.md:
+
+- **Always include:** the accent color hex, background color hex, and any named brand shapes (e.g. "the Asabina step shape — a hexagonal isometric polygon")
+- **Add from the navigator's brief:** composition direction, style reference, mood, specific elements
+
+Example prompt assembly:
+
+```
+Navigator says: "Brockmann-style poster with the step shape"
+
+Assembled prompt:
+"A Swiss poster-style graphic inspired by Josef Müller-Brockmann.
+On a pure black (#000000) background, arrange isometric step shapes
+— the Asabina brand element, a hexagonal polygon suggesting a 3D stair
+step. One large saturated pink (#FF5583) step dominates, with smaller
+dark gray (#2A2A2A) counterpoints. Hard geometric edges, flat opaque
+color fills, strong asymmetric tension. No text, no gradients."
+```
+
+The agent enriches the navigator's brief with brand tokens — the navigator shouldn't have to remember hex codes.
+
+### Generate candidates
+
+For each prompt:
+
+1. Write the prompt to `.imagegen-output/{name}.instruct.txt`
+2. Call the Gemini API per the imagegen skill's API reference
+3. Save the image to `.imagegen-output/{name}.png`
+4. Auto-open on graphical systems (`open` on macOS, `xdg-open` on Linux)
+5. Read the image inline for the navigator to review in the conversation
+
+**Generate 2-3 variants per round** by default. Run the same prompt multiple times (image generation is stochastic) or vary the prompt slightly. Name them sequentially: `concept-v1.png`, `concept-v2.png`, `concept-v3.png`.
+
+### Check in after each round
+
+Present the candidates and ask:
+
+```
+Generated 3 variants. What's your read?
+
+Options:
+  (a) Pick one and refine — iterate the prompt with constraints
+  (b) Try a different direction — new prompt from scratch
+  (c) Good enough — move to direction selection
+  (d) Skip imagegen — go straight to Figma
+```
+
+Iterate as many rounds as the navigator wants. The goal is to exhaust the interesting part of the idea space before committing to Figma work.
+
+## Phase 2 — Direction selection
+
+When the navigator has enough candidates (from imagegen or from prior work), structure the selection:
+
+### Side-by-side review
+
+If multiple candidates exist, present them together:
+
+```
+Candidates for review:
+
+  1. concept-v2.png — diagonal tension, pink dominant lower-left
+  2. concept-v5.png — centered composition, symmetric, lighter grays
+  3. (existing Figma) Direction 1b1 — staircase with landing, opaque
+
+Which direction to pursue? Or combine elements from multiple?
+```
+
+The navigator picks. If they want to combine elements ("the composition of v2 but the color balance of 1b1"), note the synthesis for the build phase.
+
+### Optionally record the decision
+
+If the design choice is significant (brand-level, will be referenced later), offer to document it:
+
+> "This looks like a direction worth recording. Want me to capture it as a decision record via /decision?"
+
+Don't push — most design iterations don't need formal records. Only suggest for decisions that will outlive the current session.
+
+## Phase 3 — Build
+
+### Hand off to Figma
+
+Load the figma-conventions skill context. The implementation follows this protocol:
+
+1. **Reference image:** the selected candidate from Phase 2 (or the navigator's mental image if they skipped imagegen)
+2. **Components first:** use existing Figma components where available (e.g. the Step component in brand graphics). Don't recreate shapes that already exist as components.
+3. **Variables for colors:** bind all colors to Figma variables, not hardcoded hex values. Use or create a variable collection that maps to DESIGN.md tokens.
+4. **Incremental building:** work in small steps via the Figma Plugin API (`use_figma`), validating with screenshots after each step. Don't try to build a complex composition in one API call.
+
+### Concept-to-vector translation
+
+The reference image guides these aspects:
+- **Composition** — element placement, scale relationships, negative space
+- **Mood** — color temperature, contrast level, visual weight distribution
+- **Tension** — diagonal energy, asymmetry, focal points
+
+The reference image does NOT dictate:
+- **Exact geometry** — Figma shapes are built from components, not traced from raster
+- **Exact colors** — use DESIGN.md tokens, not eyedropper from the generated image
+- **Fine detail** — generated images often include artifacts, noise, or hallucinated elements. Ignore those.
+
+### Check in after each build step
+
+After each significant Figma change, take a screenshot and present it:
+
+```
+Built the base composition — 5 steps ascending from lower-left,
+pink lead step at position 3. Landing extends to the right edge.
+
+[screenshot]
+
+How does this look? Adjust composition, colors, or move on?
+```
+
+## Phase 4 — Refine
+
+### Compare to reference
+
+When the Figma implementation reaches a reviewable state, compare it to the original reference:
+
+1. Screenshot the Figma frame
+2. Display alongside the reference image (or display sequentially if side-by-side isn't possible)
+3. Note the differences:
+
+```
+Comparing to reference (concept-v2.png):
+
+  Matches:
+  ✓ Diagonal composition from lower-left to upper-right
+  ✓ Pink step as dominant element
+  ✓ Dark background with gray counterpoints
+
+  Diverges:
+  △ Reference has 4 elements, Figma has 9 (more steps in the staircase)
+  △ Reference has more negative space in upper-right
+  △ Gray tones in Figma are darker than reference
+
+Adjust, or accept the divergence?
+```
+
+### Iterate
+
+The navigator steers:
+- **Adjust colors** → tweak Figma variables (all bound nodes update)
+- **Adjust composition** → move/resize elements via Plugin API
+- **Try a different approach** → loop back to Phase 1 (new concept) or Phase 3 (rebuild)
+- **Accept** → the design is done for this session
+
+### Wrap up
+
+When the navigator is satisfied (or the session ends):
+
+1. Summarize what was accomplished
+2. If a ticket is attached, comment the progress to Linear (via `/comment`)
+3. If the Figma work produced a reviewable artifact, note the file and frame name
+4. If there's follow-up work, note it
+
+## Anti-patterns
+
+- **Don't skip DESIGN.md.** If it exists, read it. Brand tokens are not optional context — they're the constraint space the design lives in.
+- **Don't auto-advance past visual checkpoints.** Every generated image and every Figma change needs navigator review. Design is subjective — the agent cannot evaluate aesthetic quality.
+- **Don't import generated images into Figma.** They are references, not assets. Build from components and vectors.
+- **Don't hardcode colors.** Always use DESIGN.md tokens → Figma variables. If a color isn't in DESIGN.md, flag it to the navigator rather than inventing one.
+- **Don't over-generate.** 2-3 variants per round is enough. 10 variants overwhelm the navigator and waste API calls. If the direction is clear, one variant is fine.
+- **Don't skip the reference comparison.** Phase 4 exists to catch drift between intent (the reference) and implementation (the Figma output). Skipping it lets subtle mismatches accumulate.
+- **Don't duplicate skill logic.** This skill orchestrates. The actual image generation logic lives in `/imagegen`. The Figma editing conventions live in `/figma-conventions`. The decision recording lives in `/decision`. Delegate, don't reimplement.
+- **Don't work without the navigator.** This is not a walk-away skill. Design work requires continuous aesthetic judgment that only the human can provide.

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -19,7 +19,7 @@ The defining design principles are:
 >
 > **Atomic steps with checkpoints.** Each change is small enough to steer in one pass. The human sees the change, gives design feedback, and the session continues. Checkpoints are for steering, not code review.
 >
-> **PR-always.** Code review happens on GitHub, not in the CLI chat. Every session that produces code ends with a PR. GitHub has line comments, a mobile app, and formal review flows — it's a better review surface than chat. If a PR turns out wrong, close it or drop commits — PRs are cheap.
+> **PR-early.** Open the PR after the first commit, not when the branch is "done." The PR is a living review surface — each subsequent commit shows up as a reviewable increment in the GitHub UI, which is a better modality for review than CLI chat. The author and teammates can review from the GitHub mobile app between sessions. A PR with one commit signals "work started, visibility for the team"; it doesn't mean "ready to merge." PRs are cheap; delayed visibility is expensive.
 >
 > **Parallel where possible.** Use subagents for independent exploration and implementation tasks. Don't serialize work that can run concurrently. But always reconvene with the navigator before acting on findings.
 >
@@ -361,6 +361,14 @@ For each step:
 
    **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.
 
+### Open the PR early
+
+After the first commit is pushed (Step 1), **immediately delegate to the `/pr` skill** to open the PR. Don't wait for all steps to complete — the PR is a visibility and review surface, not a completion gate. The PR title and body can reference the plan; subsequent commits appear as incremental diffs reviewable from the GitHub UI or mobile app.
+
+This means the PR opens while work is still in progress. That's intentional — the navigator (and teammates) can review each commit as it lands, provide feedback on GitHub, and track progress without needing the CLI session open.
+
+If the PR already exists (resuming a prior session), skip this step.
+
 ### Comment step completions to Linear
 
 After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a reply threaded under the plan anchor via the comment skill:
@@ -434,13 +442,11 @@ If there are uncommitted changes (checkpoint mode only):
 - If multiple logical changes are uncommitted, suggest breaking them into separate commits and provide a message for each
 - The navigator decides what to stage and commit
 
-### PR creation
+### PR check
 
-If the branch looks complete relative to the ticket scope, **delegate to the `/pr` skill.** Do not duplicate PR creation logic here — invoke it via the skill system with `skill: "pr"`.
+The PR should already exist (opened after Step 1 in Phase 3). If it doesn't (e.g. the session skipped imagegen and went straight to one commit), create it now via the `/pr` skill.
 
-The `/pr` skill handles: base branch detection (including stacked PRs), drafting the title and body from commits and the Linear ticket, pitching in chat for approval, pushing, creating via `gh`, transitioning the ticket to In Review, launching a background CI monitor, and **merge strategy** (convention reading, stack-aware merging, closing keyword bookkeeping). Do not duplicate merge logic here.
-
-If the navigator says "not yet" or "more work needed," skip. The navigator will create it when ready.
+If the branch is complete, the PR is already the review surface — no additional action needed beyond ensuring the last commit is pushed.
 
 ### Comment wrap-up to Linear
 

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -361,13 +361,15 @@ For each step:
 
    **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.
 
+9. **Push immediately.** After each commit (checkpoint or yolo), push to remote without asking. Pushing is not a HITL gate — the merge is. Pushing keeps the remote branch current, enables GitHub review of individual commits, and prevents work loss. Never ask "shall I push?" — just push.
+
 ### Open the PR early
 
 After the first commit is pushed (Step 1), **immediately delegate to the `/pr` skill** to open the PR. Don't wait for all steps to complete — the PR is a visibility and review surface, not a completion gate. The PR title and body can reference the plan; subsequent commits appear as incremental diffs reviewable from the GitHub UI or mobile app.
 
 This means the PR opens while work is still in progress. That's intentional — the navigator (and teammates) can review each commit as it lands, provide feedback on GitHub, and track progress without needing the CLI session open.
 
-If the PR already exists (resuming a prior session), skip this step.
+If the PR already exists (resuming a prior session), skip this step — just push.
 
 ### Comment step completions to Linear
 

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -44,6 +44,13 @@ The skill supports two commit modes. The navigator can switch between them at an
 
 This prevents atomic steps (like adding a dependency) from being tangled with subsequent implementation changes in the same uncommitted working tree. The hook fires on: package.json, package-lock.json, pnpm-lock.yaml, yarn.lock, Cargo.toml, Cargo.lock, flake.nix, flake.lock, pyproject.toml, poetry.lock, uv.lock, go.mod, go.sum, Gemfile, Gemfile.lock, mix.exs, mix.lock, and *.cabal files.
 
+**Signed vs unsigned commits.** Default to `git commit` / `git push` — these produce signed, verified commits via the user's SSH key and 1Password. Fall back to `git mcommit` / `git mpush` (unsigned, HTTPS-based) only when:
+
+- The navigator has explicitly said they're leaving the computer ("I'm stepping away", "walk-away mode", "keep going while I'm out"), OR
+- The navigator has urged the agent to plow through something and signing fails (missed Touch ID prompt)
+
+If a session has used `mcommit`/`mpush`, the PR contains unsigned commits — which is the intended signal for AI-produced work. **The merge gate is harder for unsigned PRs:** do not merge without explicit human approval, because the entire commit chain lacked interactive verification. The merge is where the human-in-the-loop catches up.
+
 **System-scope commands are always HITL, even in yolo mode.** Commands that modify system state (`brew install`, `npm install -g`, `pip install`, `cargo install`, etc.) are never auto-approved. When a tool is missing, surface it to the navigator with context (e.g. "gitleaks is required by the pre-commit hook — install via `nix develop` or approve `brew install gitleaks`?") rather than resolving it silently. Imperative installs bypass version control and can't be reviewed or rolled back.
 
 At the start of the session, if the skill detects this is a fresh ticket with no prior work, ask:

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -10,6 +10,8 @@ Create a pull request. **Fast, good defaults, operator confirms before anything 
 
 The defining design principles:
 
+> **PR early.** Open the PR after the first commit, not when the branch is "done." A PR with one commit signals "work started" and gives the team visibility. Subsequent commits show up as reviewable increments in the GitHub UI — the author can self-review from the mobile app between sessions, and teammates see progress without needing CLI access. PRs are cheap; delayed visibility is expensive.
+>
 > **DX-first.** Derive as much as possible automatically — base branch, title, body. The operator should need to type as little as possible.
 >
 > **Pitch before creating.** Always show the full draft in chat and get explicit approval. Never run `gh pr create` without confirmation.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -322,6 +322,23 @@ gh pr list --base <branch-being-merged> --state open --json number,title
 
 **Never use `--delete-branch` when the branch is another PR's base.** GitHub auto-closes child PRs when their base branch is deleted, requiring a rebase and new PR to recover.
 
+### Unsigned commit safety gate
+
+Before offering to merge, check whether the PR contains unsigned commits (produced via `git mcommit` / `git mpush` during walk-away or fallback sessions). Unsigned commits show as "Unverified" on GitHub — this is the intended signal for AI-produced work that lacked interactive human verification.
+
+**If the PR contains any unsigned commits:** the merge requires explicit human approval. Surface it clearly:
+
+```
+⚠️  This PR contains unsigned commits — produced without interactive verification.
+    Merge requires explicit human approval.
+    
+    Review the full diff before approving: gh pr diff <number>
+```
+
+Do not merge unsigned PRs on the agent's own initiative, even if CI is green and the navigator previously said "go ahead" in a different context. The merge is where the human-in-the-loop catches up on unverified work.
+
+**If all commits are signed:** proceed normally — the human was interactively present for each commit.
+
 ### Merge strategy
 
 The skill must determine *how* to merge before offering the merge action. The decision tree:


### PR DESCRIPTION
## Summary
- Add `skills/design/SKILL.md` — orchestrates the full visual design workflow: DESIGN.md brand tokens → imagegen concept generation → direction selection → Figma implementation → feedback loops
- Delegates to specialized skills (`/imagegen`, `/figma-conventions`, `/decision`) rather than duplicating logic — this is a choreography skill
- Auto-enriches imagegen prompts with brand tokens from DESIGN.md (the navigator shouldn't have to remember hex codes)
- `/pair` already detects design-focused tickets and delegates here (added in KB-76 PR #64)

Closes KB-77

## Test plan
- [ ] Invoke `/design` and verify skill triggers on design-related prompts
- [ ] Verify Phase 0 reads DESIGN.md and presents brand token summary
- [ ] Verify imagegen integration: prompt enrichment with brand colors, `.instruct.txt` sidecar, auto-open
- [ ] Verify `/pair` passthrough: pair on a design-labeled ticket → delegates to `/design`

🤖 Generated with [Claude Code](https://claude.com/claude-code)