### PR TITLE
feat(templates): declare binding norms in github-settings [KB-82]

### DIFF
--- a/.github-settings.yaml
+++ b/.github-settings.yaml
@@ -1,24 +1,39 @@
 # Intended GitHub repo settings for asabina-de/kb.
 # Read by the /pr skill (Phase 1.1) to detect configuration drift.
 # Not consumed by CI or GitHub directly.
+#
+# Norm levels (see templates/github-settings.yaml for full definitions):
+#   REQUIRED   — binding org norm; matching a misconfigured live setting
+#                is not compliance. Fix the live setting, never the spec.
+#   PREFERENCE — repo-level choice.
 
 merge:
+  # PREFERENCE: squash-merge is the only allowed method for this repo.
+  # One clean commit per PR in git log, carrying the PR title format:
+  #   type(scope): subject [TICKET-ID] (#N)
   allowed_methods:
     - squash
 
-  # Squash-merge is the only allowed method for this repo.
-  # One clean commit per PR in git log, carrying the PR title format:
-  #   type(scope): subject [TICKET-ID] (#N)
+  # PREFERENCE: org convention is squash (CONTRIBUTING.md "PR Merge
+  # Strategy").
   default_method: squash
 
-  # CRITICAL: must be "pr_title" — GitHub's factory default uses the
-  # commit message for single-commit PRs, silently breaking conventions.
-  # Configure in GitHub Settings > Pull Requests > "Allow squash merging".
+  # REQUIRED: must be "pr_title" — GitHub's factory default uses the
+  # head commit's message for single-commit PRs, silently dropping the
+  # [TICKET-ID] from git log.
+  # Live setting: gh api repos/asabina-de/kb -X PATCH -f squash_merge_commit_title=PR_TITLE
   squash_title: pr_title
 
+  # REQUIRED: must be "commit_messages" so Co-authored-by/Assisted-by
+  # provenance trailers from individual commits survive the squash.
+  # Live setting: gh api repos/asabina-de/kb -X PATCH -f squash_merge_commit_message=COMMIT_MESSAGES
+  squash_message: commit_messages
+
+  # PREFERENCE: auto-delete head branch after merge.
   delete_branch_on_merge: true
 
 branch_protection:
+  # PREFERENCE
   default_branch: main
   require_pr_reviews: true
   require_status_checks: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,23 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 ### Fixed
 - **`.github/workflows/lint-pr.yaml` — ticket-ID check was a no-op** — the previous `subjectPattern` (`^.+(\s\[[A-Z]+-\d+\])?$`) put the ticket-ID group behind an optional quantifier after `^.+`, so every non-empty subject passed. The [2026-06-11] claim that the workflow "validates `type(scope): subject [TICKET-ID]`" was never true (KB-81; observed downstream as ivos-trades PRs merging with no ticket ID and nothing firing). The pattern now requires the subject to end with `[TICKET-ID]`. **Escape hatch:** a PR that legitimately has no ticket declares `[noticket]` (or `[noissue]`) in the PR *description body* — the ID requirement is lifted while type/scope validation still applies. The marker lives in the body, not the title, to keep titles short. Red case demonstrated on the introducing PR (#66): an ID-less title failed CI, the corrected title passed, and the body-marker escape hatch was verified live.
 
+### Changed
+- **`templates/github-settings.yaml` — norm levels** — every field now carries **REQUIRED** (binding org norm) or **PREFERENCE** (repo-level choice). `squash_title: pr_title` is REQUIRED, and a new REQUIRED field `squash_message: commit_messages` keeps `Co-authored-by`/`Assisted-by` provenance trailers in squash commit bodies. REQUIRED semantics: the declared value is the only valid one — a spec matching a misconfigured live setting is not compliance; fix the live setting, never adopt the footgun into the spec (KB-82; observed downstream when a generate-from-live flow laundered GitHub's `commit_or_pr_title` footgun into a repo's spec).
+- **`templates/CONTRIBUTING.md` — PR merge strategy switched to squash-merge** — the template said "always merge commits — never squash", contradicting the root `CONTRIBUTING.md` and actual practice across repos (KB-59). Now: always squash-merge with the PR title as commit title source; per-commit AI provenance survives in the squash body via `squash_message: commit_messages`.
+- **`/pr` skill Phase 1.1** — the generate-from-live path now validates generated values against the KB template's norm levels: REQUIRED fields always take the norm value, and live deviations are surfaced as drift with ready-to-run `gh` fix commands instead of being adopted.
+- **`/align` skill** — repo-settings comparison treats REQUIRED-field drift as a gap even when the spec matches live settings, and validates REQUIRED fields against the norm value directly via `gh api`.
+
 ### Migration
+
+**Repo settings (manual):**
+- All squash-using repos — set both squash sources (this step was missing from the [2026-06-11] entry, so live repos were never instructed to leave GitHub's factory defaults; misconfigured repos silently drop ticket IDs from single-commit squashes and provenance trailers from all squashes):
+  ```
+  gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=COMMIT_MESSAGES
+  ```
+
+**Files:**
+- Re-sync `.github-settings.yaml` from `templates/github-settings.yaml` to pick up the norm-level markers and the `squash_message` field.
+- If your `CONTRIBUTING.md` carries the "always use merge commits" PR Merge Strategy section, replace it with the squash-merge section from `templates/CONTRIBUTING.md`.
 
 **CI/CD:**
 - Replace your repo's `.github/workflows/lint-pr.yaml` with the fixed KB copy. Any copy synced before this date carries the no-op pattern and enforces nothing — this includes customized copies, so re-apply local customizations (e.g. a different `types` list) on top of the fixed pattern.

--- a/skills/align/SKILL.md
+++ b/skills/align/SKILL.md
@@ -83,9 +83,11 @@ For each migration step, check whether the target repo has already applied it:
 - Compare against the KB template version for drift
 
 **Repo settings:**
-- Read `.github-settings.yaml` if present — compare declared settings against the KB template
+- Read `.github-settings.yaml` if present — compare declared settings against the KB template (`templates/github-settings.yaml`), respecting its norm levels:
+  - **REQUIRED fields** (`squash_title: pr_title`, `squash_message: commit_messages`): the KB template's value is the only valid one. A deviating spec is a gap **even when the spec matches the repo's live GitHub settings** — matching a misconfigured reality is not compliance; it usually means a generate-from-live flow laundered a footgun into the spec. The fix direction is always spec-and-live → norm, never norm → spec.
+  - **PREFERENCE fields**: repo-level choices — only flag when the spec and live settings disagree with each other.
 - If no `.github-settings.yaml`, flag as "repo settings not declared — unknown compliance"
-- Check observable settings via `gh api repos/{owner}/{repo}` if `gh` is available
+- Check observable settings via `gh api repos/{owner}/{repo}` if `gh` is available — validate REQUIRED fields against the norm value directly, not just against the local spec
 
 **Tickets:**
 - Fetch open issues from Linear (e.g. `list_issues` filtered by project/team)

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -68,27 +68,31 @@ Surface a one-time setup prompt after the PR is created (Phase 5), not before �
    (c) Skip — not now
 ```
 
-On (a): read the repo's current settings via the GitHub API, generate a `.github-settings.yaml` matching what's configured, and present it for approval. On (b): point to `templates/github-settings.yaml` in the kb repo. On (c): skip silently. Don't ask again in the same session.
+On (a): read the repo's current settings via the GitHub API and draft a `.github-settings.yaml` — but validate every generated value against the KB template's norm levels before presenting (read `templates/github-settings.yaml` via the `./kb` or `./knowledge-base` symlink if present; otherwise fall back to the schema reference below). **Never launder a live footgun into the spec:** for fields the KB template marks REQUIRED (`squash_title: pr_title`, `squash_message: commit_messages`), write the norm value into the generated file regardless of what the live setting says, and flag the live deviation as drift with a ready-to-run `gh` fix command (HITL guardrail below). Only PREFERENCE fields adopt live values. Generate-from-live without this validation turns a misconfigured repo into a "compliant" spec — that's how GitHub's title-source footgun got written into a downstream repo's spec, and `/align` then had no basis to flag it. On (b): point to `templates/github-settings.yaml` in the kb repo. On (c): skip silently. Don't ask again in the same session.
 
 **Schema reference (`templates/github-settings.yaml`):**
 
 ```yaml
 merge:
-  allowed_methods: [merge, squash, rebase]
-  default_method: merge
-  squash_title: pr_title
-  delete_branch_on_merge: true
+  allowed_methods: [merge, squash, rebase]   # PREFERENCE
+  default_method: squash                     # PREFERENCE
+  squash_title: pr_title                     # REQUIRED
+  squash_message: commit_messages            # REQUIRED
+  delete_branch_on_merge: true               # PREFERENCE
 
-branch_protection:
+branch_protection:                           # PREFERENCE (all fields)
   default_branch: main
   require_pr_reviews: true
   require_status_checks: true
 ```
 
+Norm levels: **REQUIRED** fields are binding org norms — the declared value is the only valid one. Drift in live settings gets fixed live (surface the `gh` command), never adopted into the spec; a spec that matches a misconfigured reality is not compliant. **PREFERENCE** fields are repo-level choices.
+
 Fields:
 - `merge.allowed_methods` — which merge buttons are enabled on GitHub
 - `merge.default_method` — which method is selected by default
-- `merge.squash_title` — squash-merge commit title source: `"pr_title"` (recommended) or `"commit_message"` (GitHub's footgun default)
+- `merge.squash_title` — squash-merge commit title source: `"pr_title"` (REQUIRED) — GitHub's `"commit_message"` factory default uses the head commit's subject for single-commit PRs, silently dropping the `[TICKET-ID]` from git log
+- `merge.squash_message` — squash-merge commit message (body) source: `"commit_messages"` (REQUIRED) — keeps `Co-authored-by`/`Assisted-by` provenance trailers from individual commits in the squash commit body
 - `merge.delete_branch_on_merge` — auto-delete head branch after merge
 - `branch_protection.default_branch` — the branch protection rules apply to
 - `branch_protection.require_pr_reviews` — require PR review before merge

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -186,8 +186,7 @@ Individual commits and merged PRs serve different audiences in `git log`:
 | Layer | Format | Ticket ID? | When visible |
 |---|---|---|---|
 | Individual commit | `type(scope): subject [ai:agent]` | No — branch encodes it | Always |
-| Merged PR (squash) | `type(scope): subject [TICKET-ID] (#N)` | Yes — for traceability | After squash-merge |
-| Merged PR (merge commit) | `type(scope): subject [TICKET-ID] (#N)` | Yes — on merge commit | After merge-commit |
+| Squash-merged PR | `type(scope): subject [TICKET-ID] (#N)` | Yes — for traceability | After squash-merge |
 
 The ticket ID suffix is the visual signal that distinguishes a squash-merged PR from an individual commit when scanning `git log`. It also makes every merged PR traceable back to its Linear ticket without opening GitHub.
 
@@ -197,18 +196,20 @@ Repos using this convention should add the `amannn/action-semantic-pull-request`
 
 ## PR Merge Strategy
 
-**Always use merge commits** — never squash unless explicitly requested by the reviewer.
+**Always use squash-merge** with "Pull request title" as the commit message source.
 
 **Rationale:**
 
-- Squash loses per-commit provenance — you can no longer see which commits were `[ai:claude]` vs human-authored
-- Squash collapses the atomic commit history that was carefully structured during development
-- Merge commits preserve the full trail for `git bisect`, `git blame`, and audit
+- Squash produces one clean commit per PR in `git log`, carrying the PR title format `type(scope): subject [TICKET-ID] (#N)`
+- Every merged PR is traceable to its Linear ticket via the `[TICKET-ID]` suffix
+- The PR title is the traceability surface — individual commits within a PR are development noise in the mainline history
+- AI provenance survives: the `Co-authored-by:`/`Assisted-by:` trailers from individual commits are preserved in the squash commit body, provided GitHub's squash commit *message* source is "commit messages" — see `.github-settings.yaml`
+- GitHub must be configured to use "Pull request title" (not the factory default) as the squash commit *title* source — the default silently uses the head commit's subject for single-commit PRs, dropping the `[TICKET-ID]`. See `.github-settings.yaml`.
 
 When merging:
 
-- Use the default merge commit strategy (`git merge --no-ff` / GitHub's "Create a merge commit")
-- The PR title becomes the merge commit subject — keep it clean
+- Use squash-merge (GitHub's "Squash and merge")
+- The PR title becomes the squash commit subject — keep it clean
 - Delete the branch after merge
 
 <!-- OPTIONAL APPENDIX: Uncomment if your project uses milestone-based development

--- a/templates/github-settings.yaml
+++ b/templates/github-settings.yaml
@@ -1,38 +1,64 @@
 # Declares intended GitHub repo settings so the /pr skill can detect
 # configuration drift. Copy to your repo root as `.github-settings.yaml`
-# and customize.
+# and customize the PREFERENCE fields.
 #
 # This file is read by LLMs (the /pr skill's Phase 1.1 repo config
-# check), not by CI or GitHub directly. Comments here give the LLM
-# context for why each setting matters.
+# check and /align's template comparison), not by CI or GitHub directly.
+# Comments here give the LLM context for why each setting matters.
+#
+# Norm levels — every field carries one:
+#
+#   REQUIRED   — binding org norm. The declared value is the only valid
+#                value. /align treats any deviation as a gap and /pr
+#                flags violations EVEN WHEN the repo's spec file and its
+#                live GitHub settings agree with each other — matching a
+#                misconfigured reality is not compliance. Never adopt a
+#                live setting into a REQUIRED field; fix the live setting
+#                instead. Changing a REQUIRED value is an org-level
+#                decision that belongs in the KB, not in one repo's copy.
+#   PREFERENCE — repo-level choice. The value here is a sane default;
+#                customize freely per repo.
 
 merge:
-  # Which merge buttons are enabled in GitHub Settings > Pull Requests.
+  # PREFERENCE: which merge buttons are enabled in GitHub Settings >
+  # Pull Requests.
   allowed_methods:
     - merge
     - squash
     - rebase
 
-  # Which method is selected by default when merging a PR.
-  default_method: merge
+  # PREFERENCE: which method is selected by default when merging a PR.
+  # Org convention is squash-merge (see CONTRIBUTING.md "PR Merge
+  # Strategy") — deviate only with a documented reason.
+  default_method: squash
 
-  # Squash-merge commit title source. GitHub's factory default uses the
-  # commit message for single-commit PRs but the PR title for multi-commit
-  # PRs — this inconsistency silently breaks commit conventions.
-  # Set to "pr_title" so squash-merged commits always use the PR title,
-  # producing consistent `type(scope): subject [TICKET-ID] (#N)` entries
-  # in git log.
+  # REQUIRED: squash-merge commit TITLE source. GitHub's factory default
+  # uses the head commit's message for single-commit PRs but the PR
+  # title for multi-commit PRs — this inconsistency silently drops the
+  # `[TICKET-ID]` from single-commit PRs and breaks git-log
+  # traceability (the ivos-trades incident: correct PR titles landed as
+  # ID-less squash commits). Must be "pr_title" so squash-merged
+  # commits always use the PR title, producing consistent
+  # `type(scope): subject [TICKET-ID] (#N)` entries in git log.
+  # Live setting: gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_title=PR_TITLE
   squash_title: pr_title
 
-  # Auto-delete head branch after merge.
+  # REQUIRED: squash-merge commit MESSAGE (body) source. Must be
+  # "commit_messages" so the Co-authored-by/Assisted-by provenance
+  # trailers from individual commits survive the squash in the commit
+  # body — the AI-provenance model in CONTRIBUTING.md depends on this.
+  # Live setting: gh api repos/{owner}/{repo} -X PATCH -f squash_merge_commit_message=COMMIT_MESSAGES
+  squash_message: commit_messages
+
+  # PREFERENCE: auto-delete head branch after merge.
   delete_branch_on_merge: true
 
 branch_protection:
-  # The branch these rules apply to.
+  # PREFERENCE: the branch these rules apply to.
   default_branch: main
 
-  # Require PR review before merge.
+  # PREFERENCE: require PR review before merge.
   require_pr_reviews: true
 
-  # Require CI status checks to pass before merge.
+  # PREFERENCE: require CI status checks to pass before merge.
   require_status_checks: true


### PR DESCRIPTION
## Summary
- Introduce **REQUIRED vs PREFERENCE norm levels** in `templates/github-settings.yaml`; `squash_title: pr_title` is REQUIRED, plus new REQUIRED `squash_message: commit_messages` so `Co-authored-by`/`Assisted-by` trailers survive squash.
- Resolve KB-59: `templates/CONTRIBUTING.md` merge strategy switched from "never squash" to squash-merge, matching the root file and actual practice.
- `/pr` Phase 1.1 generate-from-live now validates against KB norms — REQUIRED fields take the norm value; live footguns are flagged with `gh` fix commands, not laundered into the spec.
- `/align` treats REQUIRED-field drift as a gap even when the spec matches live settings.
- CHANGELOG backfills the missing repo-settings migration step for all squash-using repos.
- Dogfooded: KB's own `.github-settings.yaml` updated; live drift found and fixed (body source was `PR_BODY` — trailers were being dropped on this repo).

## Test plan
- [x] YAML parses (template + root spec)
- [x] Live settings verified post-fix: `PR_TITLE` + `COMMIT_MESSAGES`, squash-only buttons
- [ ] CI green on this PR

Closes KB-82, KB-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)