### PR TITLE
doc: require red-case proof for enforcement mechanisms [KB-84]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,14 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 - **`/align` skill** — repo-settings comparison treats REQUIRED-field drift as a gap even when the spec matches live settings, and validates REQUIRED fields against the norm value directly via `gh api`.
 - **`/pr` skill Phase 6 — ticket-ID survival check** — before offering any merge, the skill now predicts the exact subject that will land on the default branch (merge method × live squash title source × commit count × PR title) and warns with fix options when the ticket ID would drop — the single-commit-PR + `COMMIT_OR_PR_TITLE` factory-footgun combination that produced ID-less commits downstream is now caught pre-merge. After the merge, an outcome-level verification reads the landed commit subject and reports loudly if the ID didn't survive. Both checks honor the `[noticket]`/`[noissue]` PR-body escape hatch (KB-83).
 
+### Added
+- **Enforcement Mechanisms principle** in `CONTRIBUTING.md` and `templates/CONTRIBUTING.md` — **no enforcement mechanism merges without a demonstrated red case** (KB-84). A mechanism never seen failing must be assumed to enforce nothing, and the claim of enforcement is what makes everyone stop double-checking. Three rules: prove the red case before merging (link the failing run in the PR/CHANGELOG), watch the outcome not just the artifact, re-prove after edits. Backed by a full audit of the KB's ~70 enforcement mechanisms (inventory on KB-84); structural gaps ticketed as KB-85 (main-history ticket-ID watcher), KB-86 (REQUIRED-settings drift watcher), KB-87 (red cases for homegrown CI). Also fixed en passant: the "≤80 characters (enforced — …)" claim in both CONTRIBUTING files was discipline presented as automation — reworded honestly.
+
 ### Migration
+
+**Files:**
+- Add the "Enforcement Mechanisms" section from `templates/CONTRIBUTING.md` to your repo's `CONTRIBUTING.md`.
+- Grep your docs for enforcement claims ("enforced", "validates", "CI checks") and verify each names a real mechanism with a demonstrated red case — reword any that describe discipline as automation.
 
 **Repo settings (manual):**
 - All squash-using repos — set both squash sources (this step was missing from the [2026-06-11] entry, so live repos were never instructed to leave GitHub's factory defaults; misconfigured repos silently drop ticket IDs from single-commit squashes and provenance trailers from all squashes):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ These patterns are **never valid** as scopes. AI agents in particular tend to in
 1. **Imperative mood:** "add feature" not "added feature" or "adding feature"
 2. **Lowercase:** no capital first letter
 3. **No period** at the end
-4. **≤80 characters** (enforced — see self-check below)
+4. **≤80 characters** (hard rule — run the self-check below; discipline-backed, no CI gate yet)
 5. **No ticket IDs** in the subject line — the branch name already encodes the ticket
 6. **Describe the change**, not the task: "add OAuth callback route" not "work on KB-123"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,16 @@ Detected when a correction needs to be made to `AGENTS.md`, `CONTRIBUTING.md`, o
 
 **Why the distinction matters:** Category B corrections must take effect immediately — deferring them means working with broken instructions for the rest of the session. Category A has no such urgency and should always be routed properly.
 
+## Enforcement Mechanisms
+
+**No enforcement mechanism merges without a demonstrated red case.**
+
+Anything that claims to enforce a convention — a CI workflow, a lint pattern, a skill quality gate, a drift check, a pre-commit hook — is held to this standard (KB-84):
+
+1. **Prove the red case before merging.** Show the mechanism failing on bad input: a CI run that went red on a bad title, a gate that fired on a bad draft. Link the proof (CI run, PR) in the PR body or CHANGELOG entry. A mechanism that has never been seen failing must be assumed to enforce nothing — and the *claim* of enforcement is what makes everyone stop double-checking. (Case in point: the lint-pr workflow shipped with an always-pass regex under a CHANGELOG entry claiming it "validates [TICKET-ID]".)
+2. **Watch the outcome, not just the artifact.** Artifact-level checks (file exists, section present, spec declared) verify that enforcement is *configured*; outcome-level checks (git log actually carries ticket IDs, live settings actually match norms) verify that it *works*. Every protected invariant needs at least one outcome-level check somewhere in its loop.
+3. **Re-prove after edits.** Changing a pattern or gate invalidates its old red case — demonstrate a new one.
+
 ## PR Title Convention
 
 PR titles follow the same conventional-commit format as individual commits, with a ticket ID suffix for traceability:

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -158,6 +158,16 @@ Detected when a correction needs to be made to `AGENTS.md`, `CONTRIBUTING.md`, o
 
 **Why the distinction matters:** Category B corrections must take effect immediately — deferring them means working with broken instructions for the rest of the session. Category A has no such urgency and should always be routed properly.
 
+## Enforcement Mechanisms
+
+**No enforcement mechanism merges without a demonstrated red case.**
+
+Anything that claims to enforce a convention — a CI workflow, a lint pattern, a quality gate, a drift check, a pre-commit hook — is held to this standard:
+
+1. **Prove the red case before merging.** Show the mechanism failing on bad input: a CI run that went red on a bad title, a gate that fired on a bad draft. Link the proof (CI run, PR) in the PR body or changelog entry. A mechanism that has never been seen failing must be assumed to enforce nothing — and the *claim* of enforcement is what makes everyone stop double-checking.
+2. **Watch the outcome, not just the artifact.** Artifact-level checks (file exists, section present, spec declared) verify that enforcement is *configured*; outcome-level checks (git log actually carries ticket IDs, live settings actually match norms) verify that it *works*. Every protected invariant needs at least one outcome-level check somewhere in its loop.
+3. **Re-prove after edits.** Changing a pattern or gate invalidates its old red case — demonstrate a new one.
+
 ## PR Title Convention
 
 PR titles follow the same conventional-commit format as individual commits, with a ticket ID suffix for traceability:

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -90,7 +90,7 @@ These patterns are **never valid** as scopes. AI agents in particular tend to in
 1. **Imperative mood:** "add feature" not "added feature" or "adding feature"
 2. **Lowercase:** no capital first letter
 3. **No period** at the end
-4. **≤80 characters** (enforced — see self-check below)
+4. **≤80 characters** (hard rule — run the self-check below; discipline-backed, no CI gate yet)
 5. **No ticket IDs** in the subject line — the branch name already encodes the ticket
 6. **Describe the change**, not the task: "add OAuth callback route" not "work on Z-123"
 


### PR DESCRIPTION
## Summary
- Codify the principle in both CONTRIBUTING files: **no enforcement mechanism merges without a demonstrated red case**; watch the outcome, not just the artifact; re-prove after edits.
- Audit of ~70 KB enforcement mechanisms (CI workflows, pre-commit hooks, ~55 skill gates, 15 doc claims) — full inventory posted on KB-84. Only lint-pr has a red case (from #66, today); the two central invariants (main-history ticket IDs, REQUIRED settings) had no standing watcher.
- Follow-ups filed: KB-85 (main-history ticket-ID CI watcher), KB-86 (REQUIRED-settings drift watcher), KB-87 (red cases for homegrown CI).
- Fix the one false enforcement claim found: 80-char subject rule described as "(enforced — …)" when it's a manual self-check.
- CHANGELOG entry with downstream migration (adopt the section; grep docs for discipline-presented-as-automation claims).

## Test plan
- [ ] CI green (title lint validates [KB-84] suffix)
- [x] Audit inventory posted to KB-84 with per-mechanism verdicts

Closes KB-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)