### PR TITLE
feat(skills): add graduation gate to /decision [KB-98]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,14 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 ### Added
 
 - **`/pair` skill — readiness gate at pickup** (KB-97) — an advisory Definition-of-Ready check (the same five checks as the `/issue` scope gate) run when `/pair` picks up a ticket: it flags a not-ready ticket — or one in the `Icebox` / `Needs Scoping` status — before work starts, and offers to bounce it to `Needs Scoping`. Never blocks. Part of the readiness family (`docs/decisions/0005`).
+- **`/decision` skill — graduation gate at wrap-up** (KB-98) — an advisory readiness check surfaced when `/decision` wraps up, flagging a record that would graduate `exploring → decided` prematurely. Decision-adapted (open-questions-resolved · pull-not-push · evidence-sufficient · blast-radius/LRM) — the decidedness sibling of the `/issue` and `/pair` gates. The skill never graduates records itself (HITL); it only advises.
 
 ### Migration
 
 **Files:**
 
 - Re-sync `skills/pair/SKILL.md` if your repo vendors the KB skills — additive (new Phase 1 subsection + one anti-pattern); no other behavior changed.
+- Re-sync `skills/decision/SKILL.md` — additive (Phase 7 graduation gate + one anti-pattern).
 
 ## [2026-07-11]
 

--- a/skills/decision/SKILL.md
+++ b/skills/decision/SKILL.md
@@ -327,14 +327,31 @@ Print a concise summary:
 - **Tags used:** with reuse-or-mint justification for each
 - **Related discovered:** Linear tickets, related notes, TODO.md stubs that informed the work
 - **Open questions captured:** count and pointer to the section
+- **Graduation readiness:** whether the record looks ready to graduate to `decided`, or which checks it fails (see **Graduation gate** below)
 - **Suggested next step:** e.g., "Review the note, edit as needed, then run `/issue` on this path to file tickets from the action items."
 - **Suggested commit message** following the repo's convention (if the repo's `CLAUDE.md` documents one). Include an `[ai:claude]` tag if that's the repo convention. **Do not commit** — git is HITL.
 
 If any research step failed or was skipped (e.g., web unavailable, Linear MCP absent), flag it clearly in both the wrap-up and the note's Status Log.
 
+### Graduation gate (advisory)
+
+> **ADVISORY. The skill never graduates a record itself** — `exploring → decided` is HITL (see Anti-patterns). But at wrap-up, assess whether the record is _ready to graduate_ and tell the human, so a decision isn't locked prematurely. This is the `/decision` member of the readiness family — the same premature-commitment / Last-Responsible-Moment judgment `/issue` applies at ticket creation and `/pair` at pickup, adapted for **decidedness** rather than implementability. It advises; it never blocks.
+
+Run these four checks against the record before recommending graduation:
+
+1. **Open questions resolved or deferred?** — Every item in `## Open Questions` is either answered or explicitly parked with a rationale. A record graduating with live, load-bearing open questions is premature.
+2. **Pull, not push** — is a concrete decision actually needed _now_ (something is blocked waiting on it), or are we locking "to have a decision"? The second is the smell — leave it `exploring`.
+3. **Evidence sufficient** — is the chosen option grounded in evidence that exists today (sourced findings in `## Exploration`), not speculation about the future?
+4. **Blast radius / Last Responsible Moment** — high re-litigation cost + thin evidence today → defer. Decide at the last responsible moment, not the first convenient one.
+
+**When the gate fires** (any check trips), say so in the wrap-up and recommend the record stay `exploring`, naming what's missing — rather than nudging the human to lock it. If all four pass, note that the record looks ready to graduate (the human still makes the call and performs the transition).
+
+> **Sync note:** This is the decision-adapted member of the shared **premature-commitment** gate, mirrored as the `/issue` scope gate (`skills/issue/SKILL.md`, ticket creation) and the `/pair` readiness gate (`skills/pair/SKILL.md`, ticket pickup). Those apply the Definition of Ready to _tickets_ (implementability); this applies the same _spirit_ to _decision records_ (decidedness), so the checks differ deliberately — keep the shared Last-Responsible-Moment / pull-not-push principle at parity, not the literal wording. Skills are self-contained (see CLAUDE.md "Skill Architecture Constraints").
+
 ## Anti-patterns
 
 - **Don't transition frontmatter status.** The `status: exploring → decided` transition is HITL. The skill only creates records in `status: exploring` or extends existing ones.
+- **Don't nudge premature graduation.** The graduation gate is advisory — if the record fails a check (live open questions, push-not-pull, thin evidence, high blast radius), recommend it stay `exploring` and say why. Never pressure the human to lock a decision that isn't ready.
 - **Don't rename files.** Serial-numbered filenames are permanent. The skill only creates new files or edits existing ones in place.
 - **Don't commit or stage.** All git operations are HITL per the repo's `CLAUDE.md`.
 - **Don't skip scope discovery.** Prefer extending an existing note. Duplication erodes the knowledge base and fragments context.


### PR DESCRIPTION
## Summary

- Adds an advisory **graduation gate** to `/decision` (Phase 7 wrap-up): flags a record that would lock `exploring → decided` prematurely.
- **Decision-adapted, not a verbatim DoR copy** — a decision's readiness is *decidedness*, not implementability. Four checks: **open-questions-resolved · pull-not-push · evidence-sufficient · blast-radius/LRM**. (Verb-honesty and dependency-direction from the ticket DoR were dropped as ticket-specific.)
- The skill still **never graduates records itself** (HITL) — it only advises at wrap-up, since the human performs the transition.
- Sync note keeps the shared premature-commitment / Last-Responsible-Moment spirit at parity with `/issue` (creation) and `/pair` (pickup).

**Completes the readiness-gate family:** `/issue` create ✅ · `/pair` pickup ✅ · `/decision` graduate (this).

## Test plan

- Review the Phase 7 "Graduation gate" subsection + the companion anti-pattern.
- CI: skills-sync / PR-title / Linear-deployment checks.

Unsigned commit (AI work; SSH signing down this session) → merge is your call.

Closes KB-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)