### PR TITLE
feat(skills): honor draft/ready PR lifecycle in /pair + /pr [KB-106]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ Tag manual-only steps with **(manual)** so readers know an agent can't automate 
 
 ---
 
+## [2026-07-15]
+
+### Changed
+
+- **`/pair` + `/pr` skills — honest draft/ready PR lifecycle** (KB-106, KB-12) — the ticket's "In Review" status now tracks the PR's draft state. `/pr` transitions to In Review only when the PR is opened **ready**, not as a draft (KB-12); `/pair` wrap-up **flips a completed draft PR to ready** (`gh pr ready`) and transitions to In Review at that point (KB-106). A finished branch's PR no longer sits stuck in Draft, and a WIP draft no longer falsely signals "ready for review."
+
+### Migration
+
+**Files:**
+
+- Re-sync `skills/pair/SKILL.md` and `skills/pr/SKILL.md` if your repo vendors the KB skills — additive behavior on the draft/ready lifecycle.
+
 ## [2026-07-13]
 
 ### Added

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -481,7 +481,13 @@ If there are uncommitted changes (checkpoint mode only):
 
 The PR should already exist (opened after Step 1 in Phase 3). If it doesn't (e.g. the session skipped imagegen and went straight to one commit), create it now via the `/pr` skill.
 
-If the branch is complete, the PR is already the review surface — no additional action needed beyond ensuring the last commit is pushed.
+When the branch work is complete, promote the PR out of draft and hand it off for review:
+
+1. **Ensure the last commit is pushed.**
+2. **Flip the draft to ready** — if the PR is still a draft (opened PR-early in Phase 3), run `gh pr ready <n>` now that the work is done. A completed PR left in `Draft` blocks the merge button and signals "still WIP" to the team.
+3. **Transition the ticket to In Review** — this is the moment it moves to In Review (a draft PR deferred it at creation — see `/pr` Phase 5). Update the issue (e.g. `save_issue`, `state: "In Review"`).
+
+The flip is tied to completion, not memory — don't leave a finished branch's PR in draft.
 
 ### Comment wrap-up to Linear
 
@@ -506,6 +512,7 @@ Skill("comment", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"✅ 
 
 - **Don't work silently for long stretches.** This is pairing, not autonomous mode. Check in after each atomic step. If exploration takes a while, print progress notes.
 - **Don't commit in checkpoint mode.** All git write operations are HITL unless the navigator explicitly switched to yolo mode.
+- **Don't leave a finished branch's PR in draft.** When the work is complete, flip the draft to ready (`gh pr ready`) and move the ticket to In Review at wrap-up (Phase 4). A completed PR stuck in draft blocks the merge button and reads as WIP.
 - **Don't skip the derisk phase.** Feasibility unknowns caught early save time. Don't jump to implementation because "it's probably fine."
 - **Don't hard-block on the readiness gate.** It's advisory like `/issue`'s scope gate — surface a not-ready ticket (failing the Definition of Ready, or sitting in `Icebox`/`Needs Scoping`) and offer to bounce it to `Needs Scoping`, but the navigator always decides. Never refuse to pick up work.
 - **Don't serialize parallelizable work.** If two steps are independent, use subagents. The navigator's time is valuable.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -275,8 +275,10 @@ Ask the user for their response. Options:
    )"
    ```
    **Do NOT use `mcp__github__create_pull_request` for PR creation.** The MCP tool escapes newlines as literal `\n` in the body parameter, producing a single-line wall of text on GitHub. This was observed on multiple PRs (yo-convo-bot#50, ivos-trades#4) and is a known limitation of how the MCP tool serializes multi-line strings. The `gh` CLI with heredocs preserves actual newlines. Other GitHub MCP tools (read, update, merge) are fine — the issue is specific to the `body` field on `create_pull_request`.
+
+   **Draft vs ready:** open with `--draft` when the PR is a work-in-progress surface (the PR-early case — e.g. invoked from `/pair` right after the first commit). Open ready (no `--draft`) when the branch work is already complete. A draft defers the In-Review transition in step 4 until it's promoted to ready (see `/pair` Phase 4).
 3. **Print the PR URL** from the `gh` output.
-4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, update the issue on Linear (e.g. `save_issue`) with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
+4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1 **and the PR was opened ready (not a draft)**, update the issue on Linear (e.g. `save_issue`) with `id: {ticket-id}` and `state: "In Review"`. **A draft PR does not transition the ticket** — a draft is work-in-progress, so moving it to In Review would falsely tell reviewers the work is ready. The In-Review transition happens when the draft is promoted to ready (see `/pair` Phase 4 wrap-up).
 
 ## Phase 6 — Monitor CI
 
@@ -473,6 +475,7 @@ Group by platform on separate lines for readability. GitHub parses `#N` (numeric
 
 ## Anti-patterns
 
+- **Don't set In Review on a draft PR.** A draft is work-in-progress; In Review means a reviewer's eyes are actually wanted. Transition the ticket only when the PR is opened ready, or when a draft is promoted to ready (`/pair` Phase 4).
 - **Don't hardcode `main` as base.** Always detect the default branch and check for stacking.
 - **Don't create the PR without pitching.** The operator must see and approve the draft.
 - **Don't fabricate the test plan.** Derive it from the diff or say "verify manually" — don't invent test steps that don't exist.


### PR DESCRIPTION
## Summary

Makes the ticket's **In-Review** status track the PR's **draft** state — two coupled halves, folded because they're inseparable:

- **`/pr`** transitions the ticket to In Review **only when the PR is opened ready**, not as a draft (**KB-12**).
- **`/pair`** wrap-up **flips a completed draft PR to ready** (`gh pr ready`) and transitions to In Review *at that point* (**KB-106**).

Fixes both failure modes we hit this session: a completed PR stuck in `Draft` (blocks merge, reads as WIP), and a WIP draft falsely showing In Review. KB-106's flip is a no-op if `/pr` already set In Review at draft creation — hence one PR, not two.

Changes: `/pr` Phase 5 (create-time draft note + draft-aware In-Review transition) + anti-pattern; `/pair` Phase 4 (wrap-up flip-to-ready + In Review) + anti-pattern; CHANGELOG.

## Test plan

- Review the `/pr` Phase 5 and `/pair` Phase 4 changes + the two anti-patterns.
- CI: skills-sync / PR-title / Linear-deployment checks.

Unsigned commit (AI work; SSH signing down this session) → merge is your call.

Closes KB-106
Closes KB-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)